### PR TITLE
✨ Notification filters

### DIFF
--- a/lib/models/notifications/notification.dart
+++ b/lib/models/notifications/notification.dart
@@ -32,16 +32,6 @@ class OBNotification extends UpdatableModel<OBNotification> {
       this.read});
 
   static final factory = NotificationFactory();
-  static final postReaction = 'PR';
-  static final postComment = 'PC';
-  static final postCommentReply = 'PCR';
-  static final postCommentReaction = 'PCRA';
-  static final connectionRequest = 'CR';
-  static final connectionConfirmed = 'CC';
-  static final follow = 'F';
-  static final communityInvite = 'CI';
-  static final postCommentUserMention = 'PCUM';
-  static final postUserMention = 'PUM';
 
   factory OBNotification.fromJSON(Map<String, dynamic> json) {
     return factory.fromJson(json);
@@ -58,7 +48,7 @@ class OBNotification extends UpdatableModel<OBNotification> {
     }
 
     if (json.containsKey('notification_type')) {
-      type = factory.parseType(json['notification_type']);
+      type = NotificationType.parse(json['notification_type']);
     }
 
     if (json.containsKey('content_object')) {
@@ -88,7 +78,7 @@ class NotificationFactory extends UpdatableModelFactory<OBNotification> {
 
   @override
   OBNotification makeFromJson(Map json) {
-    NotificationType type = parseType(json['notification_type']);
+    NotificationType type = NotificationType.parse(json['notification_type']);
 
     return OBNotification(
         id: json['id'],
@@ -103,38 +93,6 @@ class NotificationFactory extends UpdatableModelFactory<OBNotification> {
   User parseUser(Map userData) {
     if (userData == null) return null;
     return User.fromJson(userData);
-  }
-
-  NotificationType parseType(String notificationTypeStr) {
-    if (notificationTypeStr == null) return null;
-
-    NotificationType notificationType;
-    if (notificationTypeStr == OBNotification.postReaction) {
-      notificationType = NotificationType.postReaction;
-    } else if (notificationTypeStr == OBNotification.postComment) {
-      notificationType = NotificationType.postComment;
-    } else if (notificationTypeStr == OBNotification.postCommentReply) {
-      notificationType = NotificationType.postCommentReply;
-    } else if (notificationTypeStr == OBNotification.postCommentReaction) {
-      notificationType = NotificationType.postCommentReaction;
-    } else if (notificationTypeStr == OBNotification.postCommentUserMention) {
-      notificationType = NotificationType.postCommentUserMention;
-    } else if (notificationTypeStr == OBNotification.postUserMention) {
-      notificationType = NotificationType.postUserMention;
-    } else if (notificationTypeStr == OBNotification.connectionRequest) {
-      notificationType = NotificationType.connectionRequest;
-    } else if (notificationTypeStr == OBNotification.connectionConfirmed) {
-      notificationType = NotificationType.connectionConfirmed;
-    } else if (notificationTypeStr == OBNotification.follow) {
-      notificationType = NotificationType.follow;
-    } else if (notificationTypeStr == OBNotification.communityInvite) {
-      notificationType = NotificationType.communityInvite;
-    } else {
-      // Don't throw as we might introduce new notifications on the API which might not be yet in code
-      print('Unsupported notification type');
-    }
-
-    return notificationType;
   }
 
   dynamic parseContentObject(
@@ -188,15 +146,71 @@ class NotificationFactory extends UpdatableModelFactory<OBNotification> {
   }
 }
 
-enum NotificationType {
-  postReaction,
-  postComment,
-  postCommentReply,
-  postCommentReaction,
-  connectionRequest,
-  connectionConfirmed,
-  follow,
-  communityInvite,
-  postCommentUserMention,
-  postUserMention,
+class NotificationType {
+  // Using a custom-built enum class to link the notification type strings
+  // directly to the matching enum constants.
+  // This class can still be used in switch statements as a normal enum.
+  final String code;
+
+  const NotificationType._internal(this.code);
+
+  toString() => code;
+
+  static const postReaction = const NotificationType._internal('PR');
+  static const postComment = const NotificationType._internal('PC');
+  static const postCommentReply = const NotificationType._internal('PCR');
+  static const postCommentReaction = const NotificationType._internal('PCRA');
+  static const connectionRequest = const NotificationType._internal('CR');
+  static const connectionConfirmed = const NotificationType._internal('CC');
+  static const follow = const NotificationType._internal('F');
+  static const communityInvite = const NotificationType._internal('CI');
+  static const postCommentUserMention = const NotificationType._internal('PCUM');
+  static const postUserMention = const NotificationType._internal('PUM');
+
+  static const _values = const <NotificationType>[
+    postReaction,
+    postComment,
+    postCommentReply,
+    postCommentReaction,
+    connectionRequest,
+    connectionConfirmed,
+    follow,
+    communityInvite,
+    postCommentUserMention,
+    postUserMention
+  ];
+
+  static values() => _values;
+
+  static NotificationType parse(String string) {
+    if (string == null) return null;
+
+    NotificationType notificationType;
+    if (string == postReaction.code) {
+      notificationType = postReaction;
+    } else if (string == postComment.code) {
+      notificationType = postComment;
+    } else if (string == postCommentReply.code) {
+      notificationType = postCommentReply;
+    } else if (string == postCommentReaction.code) {
+      notificationType = postCommentReaction;
+    } else if (string == connectionRequest.code) {
+      notificationType = connectionRequest;
+    } else if (string == connectionConfirmed.code) {
+      notificationType = connectionConfirmed;
+    } else if (string == follow.code) {
+      notificationType = follow;
+    } else if (string == communityInvite.code) {
+      notificationType = communityInvite;
+    } else if (string == postCommentUserMention.code) {
+      notificationType = postCommentUserMention;
+    } else if (string == postUserMention.code) {
+      notificationType = postUserMention;
+    } else {
+      // Don't throw as we might introduce new notifications on the API which might not be yet in code
+      print('Unsupported notification type');
+    }
+
+    return notificationType;
+  }
 }

--- a/lib/models/notifications/notification.dart
+++ b/lib/models/notifications/notification.dart
@@ -169,6 +169,7 @@ class NotificationType {
 
   static const _values = const <NotificationType>[
     postReaction,
+    postCommentReaction,
     postComment,
     postCommentReply,
     postCommentReaction,

--- a/lib/models/push_notification.dart
+++ b/lib/models/push_notification.dart
@@ -5,15 +5,15 @@ class PushNotification {
     if (pushNotificationTypeStr == null) return null;
 
     PushNotificationType pushNotificationType;
-    if (pushNotificationTypeStr == OBNotification.postReaction) {
+    if (pushNotificationTypeStr == NotificationType.postReaction.code) {
       pushNotificationType = PushNotificationType.postReaction;
-    } else if (pushNotificationTypeStr == OBNotification.postComment) {
+    } else if (pushNotificationTypeStr == NotificationType.postComment.code) {
       pushNotificationType = PushNotificationType.postComment;
-    } else if (pushNotificationTypeStr == OBNotification.connectionRequest) {
+    } else if (pushNotificationTypeStr == NotificationType.connectionRequest.code) {
       pushNotificationType = PushNotificationType.connectionRequest;
-    } else if (pushNotificationTypeStr == OBNotification.follow) {
+    } else if (pushNotificationTypeStr == NotificationType.follow.code) {
       pushNotificationType = PushNotificationType.follow;
-    } else if (pushNotificationTypeStr == OBNotification.communityInvite) {
+    } else if (pushNotificationTypeStr == NotificationType.communityInvite.code) {
       pushNotificationType = PushNotificationType.communityInvite;
     } else {
       throw 'Unsupported push notification type';

--- a/lib/pages/home/pages/notifications/notifications.dart
+++ b/lib/pages/home/pages/notifications/notifications.dart
@@ -112,7 +112,12 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
     var widgets = <Widget>[];
 
     if (_showFilters) {
-      widgets.add(OBNotificationFilter(_filter, _filtersUpdated));
+      widgets.add(
+        Padding(
+          padding: EdgeInsets.only(bottom: 15),
+          child: OBNotificationFilter(_filter, _filtersUpdated),
+        ),
+      );
     }
 
     widgets.add(
@@ -162,8 +167,6 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
 
   Future<List<OBNotification>> _refreshNotifications() async {
     await _readNotifications();
-
-    print("Refresh: ${_filter.getActive()}");
 
     NotificationsList notificationsList =
         await _userService.getNotifications(types: _filter.getActive());
@@ -248,7 +251,7 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
         return _filter.isActive(NotificationType.follow);
       case PushNotificationType.communityInvite:
         return _filter.isActive(NotificationType.communityInvite);
-      default :
+      default:
         print("Unsupported notification type: $type");
         return true;
     }

--- a/lib/pages/home/pages/notifications/notifications.dart
+++ b/lib/pages/home/pages/notifications/notifications.dart
@@ -184,8 +184,8 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
       List<OBNotification> currentNotifications) async {
     OBNotification lastNotification = currentNotifications.last;
     int lastNotificationId = lastNotification.id;
-    NotificationsList moreNotifications =
-        await _userService.getNotifications(maxId: lastNotificationId);
+    NotificationsList moreNotifications = await _userService.getNotifications(
+        maxId: lastNotificationId, types: _filter.getActive());
     return moreNotifications.notifications;
   }
 

--- a/lib/pages/home/pages/notifications/notifications.dart
+++ b/lib/pages/home/pages/notifications/notifications.dart
@@ -10,6 +10,7 @@ import 'package:Okuna/services/navigation_service.dart';
 import 'package:Okuna/services/push_notifications/push_notifications.dart';
 import 'package:Okuna/services/toast.dart';
 import 'package:Okuna/services/user.dart';
+import 'package:Okuna/widgets/badges/badge.dart';
 import 'package:Okuna/widgets/http_list.dart';
 import 'package:Okuna/widgets/icon.dart';
 import 'package:Okuna/widgets/icon_button.dart';
@@ -76,6 +77,8 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
       _needsBootstrap = false;
     }
 
+    var filtersCount = (_filter.hasFilter() ? _filter.getActiveCategories().length : 0);
+
     return CupertinoPageScaffold(
       navigationBar: OBThemedNavigationBar(
         title: 'Notifications',
@@ -84,6 +87,12 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
           mainAxisAlignment: MainAxisAlignment.end,
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
+            OBBadge(
+              count: filtersCount,
+            ),
+            const SizedBox(
+              width: 10,
+            ),
             OBIconButton(
               OBIcons.filter,
               themeColor: (_showFilters
@@ -91,7 +100,7 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
                   : OBIconThemeColor.secondaryText),
               onPressed: _toggleNotificationFiltersVisible,
             ),
-            Container(
+            const SizedBox(
               width: 10,
             ),
             OBIconButton(

--- a/lib/pages/home/pages/notifications/widgets/notification_filter.dart
+++ b/lib/pages/home/pages/notifications/widgets/notification_filter.dart
@@ -30,7 +30,7 @@ class OBNotificationFilter extends StatelessWidget {
             : OBIconThemeColor.primaryText),
         onPressed: () => _toggleFilter(null),
       ),
-      _createFilterButton([NotificationType.postReaction]),
+      _createFilterButton([NotificationType.postReaction, NotificationType.postCommentReaction]),
       _createFilterButton(
           [NotificationType.postComment, NotificationType.postCommentReply]),
       _createFilterButton([NotificationType.connectionRequest, NotificationType.connectionConfirmed]),
@@ -54,6 +54,7 @@ class OBNotificationFilter extends StatelessWidget {
   OBIconData _getIcon(NotificationType value) {
     switch (value) {
       case NotificationType.postReaction:
+      case NotificationType.postCommentReaction:
         return OBIcons.react;
       case NotificationType.postComment:
       case NotificationType.postCommentReply:

--- a/lib/pages/home/pages/notifications/widgets/notification_filter.dart
+++ b/lib/pages/home/pages/notifications/widgets/notification_filter.dart
@@ -1,0 +1,116 @@
+import 'package:Openbook/models/notifications/notification.dart';
+import 'package:Openbook/widgets/icon.dart';
+import 'package:Openbook/widgets/icon_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+
+class OBNotificationFilter extends StatelessWidget {
+  final ValueChanged<NotificationFilter> onFilterChange;
+
+  final NotificationFilter _filter;
+
+  OBNotificationFilter(this._filter, this.onFilterChange);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      mainAxisSize: MainAxisSize.max,
+      children: _buildIconWidgets(),
+    );
+  }
+
+  List<Widget> _buildIconWidgets() {
+    var widgets = <Widget>[
+      OBIconButton(
+        OBIcons.home,
+        themeColor: (!_filter.hasFilter()
+            ? OBIconThemeColor.primaryAccent
+            : OBIconThemeColor.primaryText),
+        onPressed: () => _toggleFilter(null),
+      ),
+      _createFilterButton([NotificationType.postReaction]),
+      _createFilterButton(
+          [NotificationType.postComment, NotificationType.postCommentReply]),
+      _createFilterButton([NotificationType.connectionRequest, NotificationType.connectionConfirmed]),
+      _createFilterButton([NotificationType.follow]),
+      _createFilterButton([NotificationType.communityInvite]),
+    ];
+
+    return widgets;
+  }
+
+  OBIconButton _createFilterButton(List<NotificationType> types) {
+    return OBIconButton(
+      _getIcon(types[0]),
+      themeColor: (_filter.hasFilter() && _filter.isActive(types[0])
+          ? OBIconThemeColor.primaryAccent
+          : OBIconThemeColor.primaryText),
+      onPressed: () => _toggleFilter(types),
+    );
+  }
+
+  OBIconData _getIcon(NotificationType value) {
+    switch (value) {
+      case NotificationType.postReaction:
+        return OBIcons.react;
+      case NotificationType.postComment:
+      case NotificationType.postCommentReply:
+        return OBIcons.comment;
+      case NotificationType.connectionRequest:
+      case NotificationType.connectionConfirmed:
+      return OBIcons.connections;
+      case NotificationType.follow:
+        return OBIcons.follow;
+      case NotificationType.communityInvite:
+        return OBIcons.communityInvites;
+      default:
+        print("Unsupported notification type: $value");
+        return OBIcons.close;
+    }
+  }
+
+  void _toggleFilter(List<NotificationType> types) {
+    if (types == null || types.isEmpty) {
+      _filter.toggleAll();
+    } else {
+      _filter.toggle(types);
+    }
+
+    onFilterChange(_filter);
+  }
+}
+
+
+class NotificationFilter {
+  List<NotificationType> lastFilters = [];
+  List<NotificationType> activeFilters = [];
+
+  bool hasFilter() => activeFilters.isNotEmpty;
+
+  bool isActive(NotificationType type) => !hasFilter() || activeFilters.contains(type);
+
+  List<NotificationType> getActive() => activeFilters;
+
+  void toggle(List<NotificationType> types) {
+    for (var type in types) {
+      if (activeFilters.contains(type)) {
+        activeFilters.remove(type);
+      } else {
+        activeFilters.add(type);
+      }
+    }
+  }
+
+  void toggleAll() {
+    if (activeFilters.isNotEmpty) {
+      lastFilters.clear();
+      lastFilters.addAll(activeFilters);
+      activeFilters.clear();
+    }
+    else if (lastFilters.isNotEmpty) {
+      activeFilters.addAll(lastFilters);
+    }
+  }
+}

--- a/lib/pages/home/pages/notifications/widgets/notification_filter.dart
+++ b/lib/pages/home/pages/notifications/widgets/notification_filter.dart
@@ -1,6 +1,6 @@
-import 'package:Openbook/models/notifications/notification.dart';
-import 'package:Openbook/widgets/icon.dart';
-import 'package:Openbook/widgets/icon_button.dart';
+import 'package:Okuna/models/notifications/notification.dart';
+import 'package:Okuna/widgets/icon.dart';
+import 'package:Okuna/widgets/icon_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 

--- a/lib/pages/home/pages/notifications/widgets/notification_filter.dart
+++ b/lib/pages/home/pages/notifications/widgets/notification_filter.dart
@@ -30,10 +30,18 @@ class OBNotificationFilter extends StatelessWidget {
             : OBIconThemeColor.primaryText),
         onPressed: () => _toggleFilter(null),
       ),
-      _createFilterButton([NotificationType.postReaction, NotificationType.postCommentReaction]),
-      _createFilterButton(
-          [NotificationType.postComment, NotificationType.postCommentReply]),
-      _createFilterButton([NotificationType.connectionRequest, NotificationType.connectionConfirmed]),
+      _createFilterButton([
+        NotificationType.postReaction,
+        NotificationType.postCommentReaction
+      ]),
+      _createFilterButton([
+        NotificationType.postComment,
+        NotificationType.postCommentReply
+      ]),
+      _createFilterButton([
+        NotificationType.connectionRequest,
+        NotificationType.connectionConfirmed
+      ]),
       _createFilterButton([NotificationType.follow]),
       _createFilterButton([NotificationType.communityInvite]),
     ];
@@ -51,23 +59,21 @@ class OBNotificationFilter extends StatelessWidget {
     );
   }
 
-  OBIconData _getIcon(NotificationType value) {
-    switch (value) {
-      case NotificationType.postReaction:
-      case NotificationType.postCommentReaction:
+  OBIconData _getIcon(NotificationType type) {
+    NotificationCategory category = NotificationFilter.getCategory(type);
+    switch (category) {
+      case NotificationCategory.Reaction:
         return OBIcons.react;
-      case NotificationType.postComment:
-      case NotificationType.postCommentReply:
+      case NotificationCategory.Comment:
         return OBIcons.comment;
-      case NotificationType.connectionRequest:
-      case NotificationType.connectionConfirmed:
-      return OBIcons.connections;
-      case NotificationType.follow:
+      case NotificationCategory.Connection:
+        return OBIcons.connections;
+      case NotificationCategory.Follow:
         return OBIcons.follow;
-      case NotificationType.communityInvite:
+      case NotificationCategory.Invite:
         return OBIcons.communityInvites;
       default:
-        print("Unsupported notification type: $value");
+        print("Unsupported notification type: $type");
         return OBIcons.close;
     }
   }
@@ -83,16 +89,52 @@ class OBNotificationFilter extends StatelessWidget {
   }
 }
 
+enum NotificationCategory { Reaction, Comment, Connection, Follow, Invite }
 
 class NotificationFilter {
   List<NotificationType> lastFilters = [];
   List<NotificationType> activeFilters = [];
 
+  static NotificationCategory getCategory(NotificationType value) {
+    switch (value) {
+      case NotificationType.postReaction:
+      case NotificationType.postCommentReaction:
+        return NotificationCategory.Reaction;
+      case NotificationType.postComment:
+      case NotificationType.postCommentReply:
+        return NotificationCategory.Comment;
+      case NotificationType.connectionRequest:
+      case NotificationType.connectionConfirmed:
+        return NotificationCategory.Connection;
+      case NotificationType.follow:
+        return NotificationCategory.Follow;
+      case NotificationType.communityInvite:
+        return NotificationCategory.Invite;
+      default:
+        print("Unsupported notification type: $value");
+        return null;
+    }
+  }
+
   bool hasFilter() => activeFilters.isNotEmpty;
 
-  bool isActive(NotificationType type) => !hasFilter() || activeFilters.contains(type);
+  bool isActive(NotificationType type) =>
+      !hasFilter() || activeFilters.contains(type);
 
   List<NotificationType> getActive() => activeFilters;
+
+  List<NotificationCategory> getActiveCategories() {
+    var list = <NotificationCategory>[];
+
+    for (NotificationType type in activeFilters) {
+      var category = getCategory(type);
+      if (!list.contains(category)) {
+        list.add(category);
+      }
+    }
+
+    return list;
+  }
 
   void toggle(List<NotificationType> types) {
     for (var type in types) {
@@ -109,8 +151,7 @@ class NotificationFilter {
       lastFilters.clear();
       lastFilters.addAll(activeFilters);
       activeFilters.clear();
-    }
-    else if (lastFilters.isNotEmpty) {
+    } else if (lastFilters.isNotEmpty) {
       activeFilters.addAll(lastFilters);
     }
   }

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -26,27 +26,31 @@ class NotificationsApiService {
     apiURL = newApiURL;
   }
 
-  Future<HttpieResponse> getNotifications({int maxId, int count, List<NotificationType> types}) {
+  Future<HttpieResponse> getNotifications(
+      {int maxId, int count, List<NotificationType> types}) {
     Map<String, dynamic> queryParams = {};
 
     if (maxId != null) queryParams['max_id'] = maxId;
 
     if (count != null) queryParams['count'] = count;
 
-    if (types != null) queryParams['types'] = types.map<String>((type) => type.code).toList();
+    if (types != null && types.isNotEmpty)
+      queryParams['types'] = types.map<String>((type) => type.code).toList();
 
     String url = _makeApiUrl(NOTIFICATIONS_PATH);
     return _httpService.get(url,
         appendAuthorizationToken: true, queryParameters: queryParams);
   }
 
-  Future<HttpieResponse> readNotifications({int maxId, List<NotificationType> types}) {
+  Future<HttpieResponse> readNotifications(
+      {int maxId, List<NotificationType> types}) {
     String url = _makeApiUrl(NOTIFICATIONS_READ_PATH);
     Map<String, dynamic> body = {};
 
     if (maxId != null) body['max_id'] = maxId.toString();
 
-    if (types != null) body['types'] = types.map<String>((type) => type.code).join(',');
+    if (types != null && types.isNotEmpty)
+      body['types'] = types.map<String>((type) => type.code).join(',');
 
     return _httpService.post(url, body: body, appendAuthorizationToken: true);
   }

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -1,3 +1,4 @@
+import 'package:Okuna/models/notifications/notification.dart';
 import 'package:Okuna/services/httpie.dart';
 import 'package:Okuna/services/string_template.dart';
 
@@ -25,23 +26,27 @@ class NotificationsApiService {
     apiURL = newApiURL;
   }
 
-  Future<HttpieResponse> getNotifications({int maxId, int count}) {
+  Future<HttpieResponse> getNotifications({int maxId, int count, List<NotificationType> types}) {
     Map<String, dynamic> queryParams = {};
 
     if (maxId != null) queryParams['max_id'] = maxId;
 
     if (count != null) queryParams['count'] = count;
 
+    if (types != null) queryParams['types'] = types.map<String>((type) => type.code).toList();
+
     String url = _makeApiUrl(NOTIFICATIONS_PATH);
     return _httpService.get(url,
         appendAuthorizationToken: true, queryParameters: queryParams);
   }
 
-  Future<HttpieResponse> readNotifications({int maxId}) {
+  Future<HttpieResponse> readNotifications({int maxId, List<NotificationType> types}) {
     String url = _makeApiUrl(NOTIFICATIONS_READ_PATH);
     Map<String, dynamic> body = {};
 
     if (maxId != null) body['max_id'] = maxId.toString();
+
+    if (types != null) body['types'] = types.map<String>((type) => type.code).join(',');
 
     return _httpService.post(url, body: body, appendAuthorizationToken: true);
   }

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -1409,9 +1409,9 @@ class UserService {
     return CategoriesList.fromJson(json.decode(response.body));
   }
 
-  Future<NotificationsList> getNotifications({int maxId, int count}) async {
+  Future<NotificationsList> getNotifications({int maxId, int count, List<NotificationType> types}) async {
     HttpieResponse response = await _notificationsApiService.getNotifications(
-        maxId: maxId, count: count);
+        maxId: maxId, count: count, types: types);
     _checkResponseIsOk(response);
     return NotificationsList.fromJson(json.decode(response.body));
   }
@@ -1423,9 +1423,9 @@ class UserService {
     return OBNotification.fromJSON(json.decode(response.body));
   }
 
-  Future<void> readNotifications({int maxId}) async {
+  Future<void> readNotifications({int maxId, List<NotificationType> types}) async {
     HttpieResponse response =
-        await _notificationsApiService.readNotifications(maxId: maxId);
+        await _notificationsApiService.readNotifications(maxId: maxId, types: types);
     _checkResponseIsOk(response);
   }
 


### PR DESCRIPTION
This PR adds filters to the notifications page, to make it easier to find e.g. connection requests and community invites among all comment and reaction notifications. This PR is a better alternative to #251  (in my opinion), and is related to issue #249. Openbook API PR #[305](https://github.com/OpenbookOrg/openbook-api/pull/305) is required for this to work.

Current functionality:
- A new filter icon is added to the notification tab.
- Clicking this icon reveals several new buttons below the Notifications header.
- Tap the buttons to filter what notifications appear (several may be selected at once):
  - House: Clears the current filter (and re-applies it if tapped again).
  - Smiley: Post reactions
  - Comment: Comments and replies
  - People: Connection requests and connection confirmations
  - Bell: Follows
  - Letter: Community invites
- A badge displays number of active filters (just like in the timeline). Note: This is not shown in the image below (old image).

- When the filter panel is open, the filter button is coloured in the accent colour of the theme.
- Closing the filter panel does *not* clear the filter, although the filter button goes grey even if a filter is still active (to show that the panel is not open).

![image](https://user-images.githubusercontent.com/7335682/60047265-95f58800-96c9-11e9-8c4b-9357bf808904.png)

Improvements before the PR is ready:
- More appropriate icons for the filter buttons.
- OBNotificationFilter currently has a "NotificationFilter" variable. I'm not sure if this is the best design here, nor if such a class should be placed in the models-folder/package.
- Do we want to change the colour behaviour of the filter button?