### PR TITLE
🐛 Selecting connections circle now disables other circles when sharing/filtering

### DIFF
--- a/lib/pages/home/modals/create_post/pages/share_post/pages/share_post_with_circles.dart
+++ b/lib/pages/home/modals/create_post/pages/share_post/pages/share_post_with_circles.dart
@@ -225,7 +225,7 @@ class OBSharePostWithCirclesPageState
         // Enable all other circles
         _setDisabledCircles([]);
         _setSelectedCircles([]);
-        _setFakeWorlCircleSelected(false);
+        _setFakeWorldCircleSelected(false);
       } else if (pressedCircle == _connectionsCircle) {
         _setDisabledCircles([]);
         _setSelectedCircles([]);
@@ -240,7 +240,7 @@ class OBSharePostWithCirclesPageState
         var disabledCircles = _circles.toList();
         disabledCircles.remove(_fakeWorldCircle);
         _setDisabledCircles(disabledCircles);
-        _setFakeWorlCircleSelected(true);
+        _setFakeWorldCircleSelected(true);
       } else if (pressedCircle == _connectionsCircle) {
         var circles = _circles.toList();
         circles.remove(_fakeWorldCircle);
@@ -333,7 +333,7 @@ class OBSharePostWithCirclesPageState
     });
   }
 
-  void _setFakeWorlCircleSelected(bool fakeWorldCircleSelected) {
+  void _setFakeWorldCircleSelected(bool fakeWorldCircleSelected) {
     setState(() {
       _fakeWorldCircleSelected = fakeWorldCircleSelected;
     });

--- a/lib/pages/home/modals/create_post/pages/share_post/pages/share_post_with_circles.dart
+++ b/lib/pages/home/modals/create_post/pages/share_post/pages/share_post_with_circles.dart
@@ -44,6 +44,7 @@ class OBSharePostWithCirclesPageState
   List<Circle> _selectedCircles;
   List<Circle> _disabledCircles;
   Circle _fakeWorldCircle;
+  Circle _connectionsCircle;
   bool _fakeWorldCircleSelected;
 
   String _circleSearchQuery;
@@ -164,8 +165,15 @@ class OBSharePostWithCirclesPageState
 
     Post createdPost;
 
-    List<Circle> selectedCircles =
-        _fakeWorldCircleSelected ? [] : _selectedCircles;
+    List<Circle> selectedCircles;
+
+    if (_fakeWorldCircleSelected) {
+      selectedCircles = [];
+    } else if (_selectedCircles.contains(_connectionsCircle)) {
+      selectedCircles = [ _connectionsCircle ];
+    } else {
+      selectedCircles = _selectedCircles;
+    }
 
     try {
       if (widget.sharePostData.image != null) {
@@ -218,6 +226,9 @@ class OBSharePostWithCirclesPageState
         _setDisabledCircles([]);
         _setSelectedCircles([]);
         _setFakeWorlCircleSelected(false);
+      } else if (pressedCircle == _connectionsCircle) {
+        _setDisabledCircles([]);
+        _setSelectedCircles([]);
       } else {
         _removeSelectedCircle(pressedCircle);
       }
@@ -230,6 +241,13 @@ class OBSharePostWithCirclesPageState
         disabledCircles.remove(_fakeWorldCircle);
         _setDisabledCircles(disabledCircles);
         _setFakeWorlCircleSelected(true);
+      } else if (pressedCircle == _connectionsCircle) {
+        var circles = _circles.toList();
+        circles.remove(_fakeWorldCircle);
+        _setSelectedCircles(circles);
+        circles = new List<Circle>.from(circles);
+        circles.remove(_connectionsCircle);
+        _setDisabledCircles(circles);
       } else {
         _addSelectedCircle(pressedCircle);
       }
@@ -268,7 +286,7 @@ class OBSharePostWithCirclesPageState
     setState(() {
       _circles = circles;
       // Move connections circle to top
-      var _connectionsCircle = _circles
+      _connectionsCircle = _circles
           .firstWhere((circle) => circle.id == user.connectionsCircleId);
       _circles.remove(_connectionsCircle);
       _circles.insert(0, _connectionsCircle);

--- a/lib/pages/home/modals/create_post/pages/share_post/pages/share_post_with_circles.dart
+++ b/lib/pages/home/modals/create_post/pages/share_post/pages/share_post_with_circles.dart
@@ -245,7 +245,7 @@ class OBSharePostWithCirclesPageState
         var circles = _circles.toList();
         circles.remove(_fakeWorldCircle);
         _setSelectedCircles(circles);
-        circles = new List<Circle>.from(circles);
+        circles = circles.toList();
         circles.remove(_connectionsCircle);
         _setDisabledCircles(circles);
       } else {


### PR DESCRIPTION
This is based on this Canny bug report: [Selecting Cycles and Connect - Logic error](https://okuna.canny.io/feature-requests/p/selecting-cycles-and-connect-logic-error).

What I've changed:
1) If you select the Connections circle when sharing a post, all other circles (except World) are auto-selected and disabled. This mirrors the behaviour of selecting the World circle.
2) If you select the Connections circle when filtering the timeline, all other circles are auto-selected and disabled.
3) Moved Connections to the top of the circle list in the timeline filter (to match the order they are in when sharing a post).