### PR TITLE
✨ Split notifications into two tabs: General and Requests

### DIFF
--- a/lib/models/notifications/notification.dart
+++ b/lib/models/notifications/notification.dart
@@ -32,16 +32,6 @@ class OBNotification extends UpdatableModel<OBNotification> {
       this.read});
 
   static final factory = NotificationFactory();
-  static final postReaction = 'PR';
-  static final postComment = 'PC';
-  static final postCommentReply = 'PCR';
-  static final postCommentReaction = 'PCRA';
-  static final connectionRequest = 'CR';
-  static final connectionConfirmed = 'CC';
-  static final follow = 'F';
-  static final communityInvite = 'CI';
-  static final postCommentUserMention = 'PCUM';
-  static final postUserMention = 'PUM';
 
   factory OBNotification.fromJSON(Map<String, dynamic> json) {
     return factory.fromJson(json);
@@ -58,7 +48,7 @@ class OBNotification extends UpdatableModel<OBNotification> {
     }
 
     if (json.containsKey('notification_type')) {
-      type = factory.parseType(json['notification_type']);
+      type = NotificationType.parse(json['notification_type']);
     }
 
     if (json.containsKey('content_object')) {
@@ -88,7 +78,7 @@ class NotificationFactory extends UpdatableModelFactory<OBNotification> {
 
   @override
   OBNotification makeFromJson(Map json) {
-    NotificationType type = parseType(json['notification_type']);
+    NotificationType type = NotificationType.parse(json['notification_type']);
 
     return OBNotification(
         id: json['id'],
@@ -103,38 +93,6 @@ class NotificationFactory extends UpdatableModelFactory<OBNotification> {
   User parseUser(Map userData) {
     if (userData == null) return null;
     return User.fromJson(userData);
-  }
-
-  NotificationType parseType(String notificationTypeStr) {
-    if (notificationTypeStr == null) return null;
-
-    NotificationType notificationType;
-    if (notificationTypeStr == OBNotification.postReaction) {
-      notificationType = NotificationType.postReaction;
-    } else if (notificationTypeStr == OBNotification.postComment) {
-      notificationType = NotificationType.postComment;
-    } else if (notificationTypeStr == OBNotification.postCommentReply) {
-      notificationType = NotificationType.postCommentReply;
-    } else if (notificationTypeStr == OBNotification.postCommentReaction) {
-      notificationType = NotificationType.postCommentReaction;
-    } else if (notificationTypeStr == OBNotification.postCommentUserMention) {
-      notificationType = NotificationType.postCommentUserMention;
-    } else if (notificationTypeStr == OBNotification.postUserMention) {
-      notificationType = NotificationType.postUserMention;
-    } else if (notificationTypeStr == OBNotification.connectionRequest) {
-      notificationType = NotificationType.connectionRequest;
-    } else if (notificationTypeStr == OBNotification.connectionConfirmed) {
-      notificationType = NotificationType.connectionConfirmed;
-    } else if (notificationTypeStr == OBNotification.follow) {
-      notificationType = NotificationType.follow;
-    } else if (notificationTypeStr == OBNotification.communityInvite) {
-      notificationType = NotificationType.communityInvite;
-    } else {
-      // Don't throw as we might introduce new notifications on the API which might not be yet in code
-      print('Unsupported notification type');
-    }
-
-    return notificationType;
   }
 
   dynamic parseContentObject(
@@ -188,15 +146,71 @@ class NotificationFactory extends UpdatableModelFactory<OBNotification> {
   }
 }
 
-enum NotificationType {
-  postReaction,
-  postComment,
-  postCommentReply,
-  postCommentReaction,
-  connectionRequest,
-  connectionConfirmed,
-  follow,
-  communityInvite,
-  postCommentUserMention,
-  postUserMention,
+class NotificationType {
+  // Using a custom-built enum class to link the notification type strings
+  // directly to the matching enum constants.
+  // This class can still be used in switch statements as a normal enum.
+  final String code;
+
+  const NotificationType._internal(this.code);
+
+  toString() => code;
+
+  static const postReaction = const NotificationType._internal('PR');
+  static const postComment = const NotificationType._internal('PC');
+  static const postCommentReply = const NotificationType._internal('PCR');
+  static const postCommentReaction = const NotificationType._internal('PCRA');
+  static const connectionRequest = const NotificationType._internal('CR');
+  static const connectionConfirmed = const NotificationType._internal('CC');
+  static const follow = const NotificationType._internal('F');
+  static const communityInvite = const NotificationType._internal('CI');
+  static const postCommentUserMention = const NotificationType._internal('PCUM');
+  static const postUserMention = const NotificationType._internal('PUM');
+
+  static const _values = const <NotificationType>[
+    postReaction,
+    postComment,
+    postCommentReply,
+    postCommentReaction,
+    connectionRequest,
+    connectionConfirmed,
+    follow,
+    communityInvite,
+    postCommentUserMention,
+    postUserMention
+  ];
+
+  static values() => _values;
+
+  static NotificationType parse(String string) {
+    if (string == null) return null;
+
+    NotificationType notificationType;
+    if (string == postReaction.code) {
+      notificationType = postReaction;
+    } else if (string == postComment.code) {
+      notificationType = postComment;
+    } else if (string == postCommentReply.code) {
+      notificationType = postCommentReply;
+    } else if (string == postCommentReaction.code) {
+      notificationType = postCommentReaction;
+    } else if (string == connectionRequest.code) {
+      notificationType = connectionRequest;
+    } else if (string == connectionConfirmed.code) {
+      notificationType = connectionConfirmed;
+    } else if (string == follow.code) {
+      notificationType = follow;
+    } else if (string == communityInvite.code) {
+      notificationType = communityInvite;
+    } else if (string == postCommentUserMention.code) {
+      notificationType = postCommentUserMention;
+    } else if (string == postUserMention.code) {
+      notificationType = postUserMention;
+    } else {
+      // Don't throw as we might introduce new notifications on the API which might not be yet in code
+      print('Unsupported notification type');
+    }
+
+    return notificationType;
+  }
 }

--- a/lib/models/notifications/notification.dart
+++ b/lib/models/notifications/notification.dart
@@ -186,27 +186,14 @@ class NotificationType {
     if (string == null) return null;
 
     NotificationType notificationType;
-    if (string == postReaction.code) {
-      notificationType = postReaction;
-    } else if (string == postComment.code) {
-      notificationType = postComment;
-    } else if (string == postCommentReply.code) {
-      notificationType = postCommentReply;
-    } else if (string == postCommentReaction.code) {
-      notificationType = postCommentReaction;
-    } else if (string == connectionRequest.code) {
-      notificationType = connectionRequest;
-    } else if (string == connectionConfirmed.code) {
-      notificationType = connectionConfirmed;
-    } else if (string == follow.code) {
-      notificationType = follow;
-    } else if (string == communityInvite.code) {
-      notificationType = communityInvite;
-    } else if (string == postCommentUserMention.code) {
-      notificationType = postCommentUserMention;
-    } else if (string == postUserMention.code) {
-      notificationType = postUserMention;
-    } else {
+    for (var type in _values) {
+      if (string == type.code) {
+        notificationType = type;
+        break;
+      }
+    }
+
+    if (notificationType == null) {
       // Don't throw as we might introduce new notifications on the API which might not be yet in code
       print('Unsupported notification type');
     }

--- a/lib/models/push_notification.dart
+++ b/lib/models/push_notification.dart
@@ -5,15 +5,15 @@ class PushNotification {
     if (pushNotificationTypeStr == null) return null;
 
     PushNotificationType pushNotificationType;
-    if (pushNotificationTypeStr == OBNotification.postReaction) {
+    if (pushNotificationTypeStr == NotificationType.postReaction.code) {
       pushNotificationType = PushNotificationType.postReaction;
-    } else if (pushNotificationTypeStr == OBNotification.postComment) {
+    } else if (pushNotificationTypeStr == NotificationType.postComment.code) {
       pushNotificationType = PushNotificationType.postComment;
-    } else if (pushNotificationTypeStr == OBNotification.connectionRequest) {
+    } else if (pushNotificationTypeStr == NotificationType.connectionRequest.code) {
       pushNotificationType = PushNotificationType.connectionRequest;
-    } else if (pushNotificationTypeStr == OBNotification.follow) {
+    } else if (pushNotificationTypeStr == NotificationType.follow.code) {
       pushNotificationType = PushNotificationType.follow;
-    } else if (pushNotificationTypeStr == OBNotification.communityInvite) {
+    } else if (pushNotificationTypeStr == NotificationType.communityInvite.code) {
       pushNotificationType = PushNotificationType.communityInvite;
     } else {
       throw 'Unsupported push notification type';

--- a/lib/pages/home/pages/notifications/notifications.dart
+++ b/lib/pages/home/pages/notifications/notifications.dart
@@ -3,10 +3,14 @@ import 'dart:async';
 import 'package:Okuna/models/notifications/notification.dart';
 import 'package:Okuna/models/notifications/notifications_list.dart';
 import 'package:Okuna/models/push_notification.dart';
+import 'package:Okuna/models/theme.dart';
 import 'package:Okuna/pages/home/lib/poppable_page_controller.dart';
 import 'package:Okuna/provider.dart';
+import 'package:Okuna/services/localization.dart';
 import 'package:Okuna/services/navigation_service.dart';
 import 'package:Okuna/services/push_notifications/push_notifications.dart';
+import 'package:Okuna/services/theme.dart';
+import 'package:Okuna/services/theme_value_parser.dart';
 import 'package:Okuna/services/toast.dart';
 import 'package:Okuna/services/user.dart';
 import 'package:Okuna/widgets/http_list.dart';
@@ -20,9 +24,11 @@ import 'package:flutter/material.dart';
 
 class OBNotificationsPage extends StatefulWidget {
   final OBNotificationsPageController controller;
+  final OBNotificationsPageTab selectedTab;
 
   OBNotificationsPage({
     this.controller,
+    this.selectedTab = OBNotificationsPageTab.general
   });
 
   @override
@@ -32,14 +38,32 @@ class OBNotificationsPage extends StatefulWidget {
 }
 
 class OBNotificationsPageState extends State<OBNotificationsPage>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, SingleTickerProviderStateMixin {
+  static const List<NotificationType> _generalTypes = <NotificationType>[
+    NotificationType.postReaction,
+    NotificationType.postCommentReaction,
+    NotificationType.postComment,
+    NotificationType.postCommentReply,
+    NotificationType.postUserMention,
+    NotificationType.postCommentUserMention,
+    NotificationType.connectionConfirmed,
+    NotificationType.follow
+  ];
+
+  static const List<NotificationType> _requestTypes = <NotificationType>[
+    NotificationType.connectionRequest,
+    NotificationType.communityInvite
+  ];
+
   UserService _userService;
   ToastService _toastService;
   NavigationService _navigationService;
+  LocalizationService _localizationService;
   PushNotificationsService _pushNotificationsService;
   OBHttpListController<OBNotification> _notificationsListController;
   StreamSubscription _pushNotificationSubscription;
   OBNotificationsPageController _controller;
+  TabController _tabController;
 
   bool _needsBootstrap;
   bool _isActivePage;
@@ -55,6 +79,19 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
     _controller = widget.controller ?? OBNotificationsPage();
     _controller.attach(state: this, context: context);
 
+    _tabController = new TabController(length: 2, vsync: this);
+
+    switch (widget.selectedTab) {
+      case OBNotificationsPageTab.general:
+        _tabController.index = 0;
+        break;
+      case OBNotificationsPageTab.requests:
+        _tabController.index = 1;
+        break;
+      default:
+        throw "Unhandled tab index: ${widget.selectedTab}";
+    }
+
     _needsBootstrap = true;
     _shouldMarkNotificationsAsRead = true;
     if (_isActivePage == null) _isActivePage = false;
@@ -62,30 +99,24 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
 
   @override
   Widget build(BuildContext context) {
+    var openbookProvider = OpenbookProvider.of(context);
+
     if (_needsBootstrap) {
-      var openbookProvider = OpenbookProvider.of(context);
       _userService = openbookProvider.userService;
       _toastService = openbookProvider.toastService;
       _navigationService = openbookProvider.navigationService;
+      _localizationService = openbookProvider.localizationService;
       _pushNotificationsService = openbookProvider.pushNotificationsService;
       _bootstrap();
       _needsBootstrap = false;
     }
 
-    List<Widget> stackItems = [
-      OBPrimaryColorContainer(
-        child: OBHttpList(
-          key: Key('notificationsList'),
-          controller: _notificationsListController,
-          listRefresher: _refreshNotifications,
-          listOnScrollLoader: _loadMoreNotifications,
-          listItemBuilder: _buildNotification,
-          resourceSingularName: 'notification',
-          resourcePluralName: 'notifications',
-          physics: const ClampingScrollPhysics(),
-        ),
-      ),
-    ];
+    ThemeService themeService = openbookProvider.themeService;
+    ThemeValueParserService themeValueParser = openbookProvider.themeValueParserService;
+    OBTheme theme = themeService.getActiveTheme();
+
+    Color tabIndicatorColor = themeValueParser.parseGradient(theme.primaryAccentColor).colors[1];
+    Color tabLabelColor = themeValueParser.parseColor(theme.primaryTextColor);
 
     return CupertinoPageScaffold(
         navigationBar: OBThemedNavigationBar(
@@ -96,9 +127,64 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
             onPressed: _onWantsToConfigureNotifications,
           ),
         ),
-        child: Stack(
-          children: stackItems,
-        ));
+        child: OBPrimaryColorContainer(
+          child: Column(
+            children: <Widget>[
+              TabBar(
+                controller: _tabController,
+                tabs: <Widget>[
+                  Padding(
+                      padding: EdgeInsets.symmetric(vertical: 5),
+                      child: Tab(text: _localizationService.notifications__tab_general()),
+                  ),
+                  Padding(
+                      padding: EdgeInsets.symmetric(vertical: 5),
+                      child: Tab(text: _localizationService.notifications__tab_requests()),
+                  ),
+                ],
+                isScrollable: false,
+                indicatorColor: tabIndicatorColor,
+                labelColor: tabLabelColor,
+              ),
+              Expanded(
+                child: TabBarView(
+                  controller: _tabController,
+                  children: <Widget>[
+                    _buildGeneralNotifications(),
+                    _buildRequestNotifications(),
+                  ],
+                )
+              )
+            ],
+          )
+        )
+    );
+  }
+
+  Widget _buildGeneralNotifications() {
+    return OBHttpList(
+      key: Key('generalNotificationsList'),
+      controller: _notificationsListController,
+      listRefresher: _refreshGeneralNotifications,
+      listOnScrollLoader: _loadMoreGeneralNotifications,
+      listItemBuilder: _buildNotification,
+      resourceSingularName: 'notification',
+      resourcePluralName: 'notifications',
+      physics: const ClampingScrollPhysics(),
+    );
+  }
+
+  Widget _buildRequestNotifications() {
+    return OBHttpList(
+      key: Key('requestNotificationsList'),
+      controller: _notificationsListController,
+      listRefresher: _refreshRequestNotifications,
+      listOnScrollLoader: _loadMoreRequestNotifications,
+      listItemBuilder: _buildNotification,
+      resourceSingularName: 'notification',
+      resourcePluralName: 'notifications',
+      physics: const ClampingScrollPhysics(),
+    );
   }
 
   void dispose() {
@@ -126,28 +212,47 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
     );
   }
 
-  Future<List<OBNotification>> _refreshNotifications() async {
-    await _readNotifications();
+  Future<List<OBNotification>> _refreshGeneralNotifications() async {
+    return _refreshNotifications(_generalTypes);
+  }
 
-    NotificationsList notificationsList = await _userService.getNotifications();
+  Future<List<OBNotification>> _refreshRequestNotifications() async {
+    return _refreshNotifications(_requestTypes);
+  }
+
+  Future<List<OBNotification>> _refreshNotifications([List<NotificationType> types]) async {
+    await _readNotifications(types: types);
+
+    NotificationsList notificationsList = await _userService.getNotifications(types: types);
     return notificationsList.notifications;
   }
 
-  Future _readNotifications() async {
+  Future _readNotifications({List<NotificationType> types}) async {
     if (_shouldMarkNotificationsAsRead &&
         _notificationsListController.hasItems()) {
       OBNotification firstItem = _notificationsListController.firstItem();
       int maxId = firstItem.id;
-      await _userService.readNotifications(maxId: maxId);
+      await _userService.readNotifications(maxId: maxId, types: types);
     }
   }
 
-  Future<List<OBNotification>> _loadMoreNotifications(
+  Future<List<OBNotification>> _loadMoreGeneralNotifications(
       List<OBNotification> currentNotifications) async {
+    return _loadMoreNotifications(currentNotifications, _generalTypes);
+  }
+
+  Future<List<OBNotification>> _loadMoreRequestNotifications(
+      List<OBNotification> currentNotifications) async {
+    return _loadMoreNotifications(currentNotifications, _requestTypes);
+  }
+
+  Future<List<OBNotification>> _loadMoreNotifications(
+      List<OBNotification> currentNotifications,
+      [List<NotificationType> types]) async {
     OBNotification lastNotification = currentNotifications.last;
     int lastNotificationId = lastNotification.id;
     NotificationsList moreNotifications =
-        await _userService.getNotifications(maxId: lastNotificationId);
+        await _userService.getNotifications(maxId: lastNotificationId, types: types);
     return moreNotifications.notifications;
   }
 
@@ -294,4 +399,9 @@ class OBNotificationsPageController extends PoppablePageController {
 
     _markNotificationsAsRead = markNotificationsAsRead;
   }
+}
+
+enum OBNotificationsPageTab {
+  general,
+  requests
 }

--- a/lib/services/localization.dart
+++ b/lib/services/localization.dart
@@ -2876,6 +2876,16 @@ class LocalizationService {
         name: 'user__follows_list_accounts_count');
   }
 
+  String notifications__tab_general() {
+    return Intl.message("General",
+        name: 'notifications__tab_general');
+  }
+
+  String notifications__tab_requests() {
+    return Intl.message("Requests",
+        name: 'notifications__tab_requests');
+  }
+
   String get notifications__settings_title {
     return Intl.message("Notifications settings",
         name: 'notifications__settings_title');

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -26,27 +26,31 @@ class NotificationsApiService {
     apiURL = newApiURL;
   }
 
-  Future<HttpieResponse> getNotifications({int maxId, int count, List<NotificationType> types}) {
+  Future<HttpieResponse> getNotifications(
+      {int maxId, int count, List<NotificationType> types}) {
     Map<String, dynamic> queryParams = {};
 
     if (maxId != null) queryParams['max_id'] = maxId;
 
     if (count != null) queryParams['count'] = count;
 
-    if (types != null) queryParams['types'] = types.map<String>((type) => type.code).toList();
+    if (types != null && types.isNotEmpty)
+      queryParams['types'] = types.map<String>((type) => type.code).toList();
 
     String url = _makeApiUrl(NOTIFICATIONS_PATH);
     return _httpService.get(url,
         appendAuthorizationToken: true, queryParameters: queryParams);
   }
 
-  Future<HttpieResponse> readNotifications({int maxId, List<NotificationType> types}) {
+  Future<HttpieResponse> readNotifications(
+      {int maxId, List<NotificationType> types}) {
     String url = _makeApiUrl(NOTIFICATIONS_READ_PATH);
     Map<String, dynamic> body = {};
 
     if (maxId != null) body['max_id'] = maxId.toString();
 
-    if (types != null) body['types'] = types.map<String>((type) => type.code).join(',');
+    if (types != null && types.isNotEmpty)
+      body['types'] = types.map<String>((type) => type.code).join(',');
 
     return _httpService.post(url, body: body, appendAuthorizationToken: true);
   }

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -1,3 +1,4 @@
+import 'package:Okuna/models/notifications/notification.dart';
 import 'package:Okuna/services/httpie.dart';
 import 'package:Okuna/services/string_template.dart';
 
@@ -25,23 +26,27 @@ class NotificationsApiService {
     apiURL = newApiURL;
   }
 
-  Future<HttpieResponse> getNotifications({int maxId, int count}) {
+  Future<HttpieResponse> getNotifications({int maxId, int count, List<NotificationType> types}) {
     Map<String, dynamic> queryParams = {};
 
     if (maxId != null) queryParams['max_id'] = maxId;
 
     if (count != null) queryParams['count'] = count;
 
+    if (types != null) queryParams['types'] = types.map<String>((type) => type.code).toList();
+
     String url = _makeApiUrl(NOTIFICATIONS_PATH);
     return _httpService.get(url,
         appendAuthorizationToken: true, queryParameters: queryParams);
   }
 
-  Future<HttpieResponse> readNotifications({int maxId}) {
+  Future<HttpieResponse> readNotifications({int maxId, List<NotificationType> types}) {
     String url = _makeApiUrl(NOTIFICATIONS_READ_PATH);
     Map<String, dynamic> body = {};
 
     if (maxId != null) body['max_id'] = maxId.toString();
+
+    if (types != null) body['types'] = types.map<String>((type) => type.code).join(',');
 
     return _httpService.post(url, body: body, appendAuthorizationToken: true);
   }

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -1409,9 +1409,9 @@ class UserService {
     return CategoriesList.fromJson(json.decode(response.body));
   }
 
-  Future<NotificationsList> getNotifications({int maxId, int count}) async {
+  Future<NotificationsList> getNotifications({int maxId, int count, List<NotificationType> types}) async {
     HttpieResponse response = await _notificationsApiService.getNotifications(
-        maxId: maxId, count: count);
+        maxId: maxId, count: count, types: types);
     _checkResponseIsOk(response);
     return NotificationsList.fromJson(json.decode(response.body));
   }
@@ -1423,9 +1423,9 @@ class UserService {
     return OBNotification.fromJSON(json.decode(response.body));
   }
 
-  Future<void> readNotifications({int maxId}) async {
+  Future<void> readNotifications({int maxId, List<NotificationType> types}) async {
     HttpieResponse response =
-        await _notificationsApiService.readNotifications(maxId: maxId);
+        await _notificationsApiService.readNotifications(maxId: maxId, types: types);
     _checkResponseIsOk(response);
   }
 


### PR DESCRIPTION
Fixes issue #249 by splitting the notification page into two tabs, one for general notifications and one for requests (currently connection requests and community invites).

![image](https://user-images.githubusercontent.com/7335682/62886812-2fd9c880-bd3c-11e9-9c10-374ff3b0f1fd.png)

This requires Okuna API PR #[305](https://github.com/OkunaOrg/okuna-api/pull/305) to function properly (without it all notifications are shown in both tabs).
