### PR TITLE
:wheelchair: fix create new post and close labels

### DIFF
--- a/lib/pages/home/modals/create_post/create_post.dart
+++ b/lib/pages/home/modals/create_post/create_post.dart
@@ -182,7 +182,7 @@ class CreatePostModalState extends State<CreatePostModal> {
 
     return OBThemedNavigationBar(
       leading: GestureDetector(
-        child: const OBIcon(OBIcons.close),
+        child: const OBIcon(OBIcons.close, semanticLabel: 'Close create new post'),
         onTap: () {
           Navigator.pop(context);
         },

--- a/lib/pages/home/modals/create_post/create_post.dart
+++ b/lib/pages/home/modals/create_post/create_post.dart
@@ -145,7 +145,7 @@ class CreatePostModalState extends State<CreatePostModal> {
 
     return CupertinoPageScaffold(
         backgroundColor: Colors.transparent,
-        navigationBar: _buildNavigationBar(),
+        navigationBar: _buildNavigationBar(_localizationService),
         child: OBPrimaryColorContainer(
             child: Column(
           children: <Widget>[
@@ -174,7 +174,7 @@ class CreatePostModalState extends State<CreatePostModal> {
         )));
   }
 
-  Widget _buildNavigationBar() {
+  Widget _buildNavigationBar(LocalizationService _localizationService) {
     bool isPrimaryActionButtonIsEnabled =
         (_isPostTextAllowedLength && _charactersCount > 0) ||
             _hasImage ||
@@ -182,7 +182,7 @@ class CreatePostModalState extends State<CreatePostModal> {
 
     return OBThemedNavigationBar(
       leading: GestureDetector(
-        child: const OBIcon(OBIcons.close, semanticLabel: 'Close create new post'),
+        child: OBIcon(OBIcons.close, semanticLabel: _localizationService.post__close_create_post_label),
         onTap: () {
           Navigator.pop(context);
         },

--- a/lib/pages/home/pages/timeline/timeline.dart
+++ b/lib/pages/home/pages/timeline/timeline.dart
@@ -4,6 +4,7 @@ import 'package:Okuna/models/post.dart';
 import 'package:Okuna/pages/home/lib/poppable_page_controller.dart';
 import 'package:Okuna/pages/home/pages/timeline/widgets/timeline-posts.dart';
 import 'package:Okuna/provider.dart';
+import 'package:Okuna/services/localization.dart';
 import 'package:Okuna/services/modal_service.dart';
 import 'package:Okuna/widgets/badges/badge.dart';
 import 'package:Okuna/widgets/buttons/button.dart';
@@ -44,6 +45,7 @@ class OBTimelinePageState extends State<OBTimelinePage> {
   Widget build(BuildContext context) {
     var openbookProvider = OpenbookProvider.of(context);
     _modalService = openbookProvider.modalService;
+    LocalizationService _localizationService = openbookProvider.localizationService;
 
     return OBCupertinoPageScaffold(
         navigationBar: OBThemedNavigationBar(
@@ -59,7 +61,7 @@ class OBTimelinePageState extends State<OBTimelinePage> {
                   right: 20.0,
                   child: Semantics(
                     button: true,
-                    label: 'Create new post',
+                    label: _localizationService.post__create_new_post_label,
                     child: OBFloatingActionButton(
                         type: OBButtonType.primary,
                         onPressed: () async {

--- a/lib/pages/home/pages/timeline/timeline.dart
+++ b/lib/pages/home/pages/timeline/timeline.dart
@@ -57,18 +57,26 @@ class OBTimelinePageState extends State<OBTimelinePage> {
               Positioned(
                   bottom: 20.0,
                   right: 20.0,
-                  child: OBFloatingActionButton(
-                      type: OBButtonType.primary,
-                      onPressed: () async {
-                        Post createdPost = await _modalService.openCreatePost(
-                            context: context);
-                        if (createdPost != null) {
-                          _timelinePostsController.addPostToTop(createdPost);
-                          _timelinePostsController.scrollToTop();
-                        }
-                      },
-                      child: const OBIcon(OBIcons.createPost,
-                          size: OBIconSize.large, color: Colors.white)))
+                  child: Semantics(
+                    button: true,
+                    label: 'Create new post',
+                    child: OBFloatingActionButton(
+                        type: OBButtonType.primary,
+                        onPressed: () async {
+                          Post createdPost = await _modalService.openCreatePost(
+                              context: context);
+                          if (createdPost != null) {
+                            _timelinePostsController.addPostToTop(createdPost);
+                            _timelinePostsController.scrollToTop();
+                          }
+                        },
+                        child: const OBIcon(OBIcons.createPost,
+                            size: OBIconSize.large, color: Colors.white)
+                    )
+                  )
+
+
+                  )
             ],
           ),
         ));

--- a/lib/services/localization.dart
+++ b/lib/services/localization.dart
@@ -1571,6 +1571,21 @@ class LocalizationService {
         name: 'post__create_new');
   }
 
+  String get post__create_new_post_label {
+    return Intl.message("Create new post",
+        name: 'post__create_new_post_label');
+  }
+
+  String get post__create_new_community_post_label {
+    return Intl.message("Create new communtiy post",
+        name: 'post__create_new_community_post_label');
+  }
+
+  String get post__close_create_post_label {
+    return Intl.message("Close create new post",
+        name: 'post__close_create_post_label');
+  }
+
   String get post__create_next {
     return Intl.message("Next",
         name: 'post__create_next');

--- a/lib/widgets/buttons/community_floating_action_button.dart
+++ b/lib/widgets/buttons/community_floating_action_button.dart
@@ -2,6 +2,7 @@ import 'package:Okuna/models/community.dart';
 import 'package:Okuna/models/post.dart';
 import 'package:Okuna/models/theme.dart';
 import 'package:Okuna/provider.dart';
+import 'package:Okuna/services/localization.dart';
 import 'package:Okuna/services/theme.dart';
 import 'package:Okuna/services/theme_value_parser.dart';
 import 'package:Okuna/widgets/buttons/button.dart';
@@ -34,6 +35,7 @@ class OBCommunityNewPostButton extends StatelessWidget {
   });
 
   Widget build(BuildContext context) {
+    LocalizationService _localizationService = OpenbookProvider.of(context).localizationService;
     return StreamBuilder(
       stream: community.updateSubject,
       initialData: community,
@@ -70,7 +72,7 @@ class OBCommunityNewPostButton extends StatelessWidget {
 
         return Semantics(
           button: true,
-          label: 'Create new community post',
+          label: _localizationService.post__create_new_community_post_label,
           child: OBFloatingActionButton(
               color: communityColor,
               textColor: textColor,

--- a/lib/widgets/buttons/community_floating_action_button.dart
+++ b/lib/widgets/buttons/community_floating_action_button.dart
@@ -68,18 +68,22 @@ class OBCommunityNewPostButton extends StatelessWidget {
           communityColor = TinyColor(communityColor).lighten(10).color;
         }
 
-        return OBFloatingActionButton(
-            color: communityColor,
-            textColor: textColor,
-            onPressed: () async {
-              OpenbookProviderState openbookProvider =
-                  OpenbookProvider.of(context);
-              Post post = await openbookProvider.modalService
-                  .openCreatePost(context: context, community: community);
-              if (post != null && onPostCreated != null) onPostCreated(post);
-            },
-            child: OBIcon(OBIcons.createPost,
-                size: OBIconSize.large, color: textColor));
+        return Semantics(
+          button: true,
+          label: 'Create new community post',
+          child: OBFloatingActionButton(
+              color: communityColor,
+              textColor: textColor,
+              onPressed: () async {
+                OpenbookProviderState openbookProvider =
+                OpenbookProvider.of(context);
+                Post post = await openbookProvider.modalService
+                    .openCreatePost(context: context, community: community);
+                if (post != null && onPostCreated != null) onPostCreated(post);
+              },
+              child: OBIcon(OBIcons.createPost,
+                  size: OBIconSize.large, color: textColor)),
+        );
       },
     );
   }

--- a/lib/widgets/icon.dart
+++ b/lib/widgets/icon.dart
@@ -10,6 +10,7 @@ class OBIcon extends StatelessWidget {
   final double customSize;
   final Color color;
   final OBIconThemeColor themeColor;
+  final String semanticLabel;
 
   static const double EXTRA_LARGE = 45.0;
   static const double LARGE_SIZE = 30.0;
@@ -17,7 +18,7 @@ class OBIcon extends StatelessWidget {
   static const double SMALL_SIZE = 15.0;
 
   const OBIcon(this.iconData,
-      {this.size, this.customSize, this.color, this.themeColor})
+      {this.size, this.customSize, this.color, this.themeColor, this.semanticLabel})
       : assert(!(color != null && themeColor != null));
 
   @override
@@ -95,6 +96,7 @@ class OBIcon extends StatelessWidget {
                 iconData.nativeIcon,
                 size: iconSize,
                 color: iconColor,
+                semanticLabel: semanticLabel ?? 'Close',
               );
             } else {
               icon = ShaderMask(

--- a/lib/widgets/icon.dart
+++ b/lib/widgets/icon.dart
@@ -96,7 +96,7 @@ class OBIcon extends StatelessWidget {
                 iconData.nativeIcon,
                 size: iconSize,
                 color: iconColor,
-                semanticLabel: semanticLabel ?? 'Close',
+                semanticLabel: semanticLabel,
               );
             } else {
               icon = ShaderMask(


### PR DESCRIPTION
Fixes Thommys recent complaints about screen reader not responding to "create new post" and close labels on many create/edit/save screens, fixed this so that it makes it way to the next release. 

We should do another comprehensive PR perhaps with an extensive accessibility review and provide more contextual labels on all our action buttons. 