### PR TITLE
:sparkles: Add globally used proxy

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:Okuna/pages/waitlist/subscribe_email_step.dart';
 import 'package:Okuna/provider.dart';
 import 'package:Okuna/pages/auth/create_account/name_step.dart';
 import 'package:Okuna/plugins/desktop/error-reporting.dart';
+import 'package:Okuna/services/httpie.dart';
 import 'package:Okuna/services/localization.dart';
 import 'package:Okuna/services/universal_links/universal_links.dart';
 import 'package:Okuna/widgets/toast.dart';
@@ -266,10 +267,11 @@ Future<Null> main() async {
   // - https://www.dartlang.org/articles/libraries/zones
 
   MyApp app;
-  runZoned<Future<Null>>(() async {
+  // run the entire app with our own HttpieOverride
+  HttpOverrides.runWithHttpOverrides<Future<Null>>(() async {
     app = MyApp();
     runApp(app);
-  }, onError: (error, stackTrace) async {
+  }, HttpieOverrides(), onError: (error, stackTrace) async {
     if (isOnDesktop) {
       DesktopErrorReporting.reportError(error, stackTrace);
       return;

--- a/lib/plugins/proxy_settings.dart
+++ b/lib/plugins/proxy_settings.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/services.dart';
+import 'package:Okuna/main.dart';
+
+class ProxySettings {
+  static const channel = const MethodChannel('social.okuna/proxy_settings');
+
+  static Future<String> findProxy(Uri url) async {
+    // mobile platforms seem to use the system proxy automatically, so return
+    // `null` to use defaults
+    if (isOnDesktop) {
+      return await channel.invokeMethod('findProxy', {'url': url.toString()});
+    } else {
+      return Future.value(null);
+    }
+  }
+}

--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -1,4 +1,5 @@
 import 'package:Okuna/pages/auth/create_account/blocs/create_account.dart';
+import 'package:Okuna/plugins/proxy_settings.dart';
 import 'package:Okuna/services/auth_api.dart';
 import 'package:Okuna/services/bottom_sheet.dart';
 import 'package:Okuna/services/categories_api.dart';
@@ -186,6 +187,8 @@ class OpenbookProviderState extends State<OpenbookProvider> {
         await EnvironmentLoader(environmentPath: ".env.json").load();
     httpService.setMagicHeader(
         environment.magicHeaderName, environment.magicHeaderValue);
+    httpService
+        .setProxy(await ProxySettings.findProxy(Uri.parse(environment.apiUrl)));
     authApiService.setApiURL(environment.apiUrl);
     postsApiService.setApiURL(environment.apiUrl);
     emojisApiService.setApiURL(environment.apiUrl);

--- a/lib/services/httpie.dart
+++ b/lib/services/httpie.dart
@@ -17,12 +17,12 @@ class HttpieService {
   String authorizationToken;
   String magicHeaderName;
   String magicHeaderValue;
+  String proxy;
   Client client;
 
   HttpieService() {
     var httpClient = HttpClient();
-    // This doesn't pick up proxy settings on Android and iOS
-    httpClient.findProxy = HttpClient.findProxyFromEnvironment;
+    httpClient.findProxy = _findProxy;
     client = IOClient(httpClient);
     client = RetryClient(client,
         when: _retryWhenResponse, whenError: _retryWhenError);
@@ -34,6 +34,14 @@ class HttpieService {
 
   bool _retryWhenError(error, StackTrace stackTrace) {
     return error is SocketException || error is ClientException;
+  }
+
+  String _findProxy(Uri url) {
+    if (proxy == null) {
+      return HttpClient.findProxyFromEnvironment(url);
+    } else {
+      return proxy;
+    }
   }
 
   void setAuthorizationToken(String token) {
@@ -59,6 +67,10 @@ class HttpieService {
   void setMagicHeader(String name, String value) {
     magicHeaderName = name;
     magicHeaderValue = value;
+  }
+
+  void setProxy(String proxy) {
+    this.proxy = proxy;
   }
 
   Future<HttpieResponse> post(url,


### PR DESCRIPTION
This PR automatically determines the proxy to use using the `ProxySettings` plugin. On mobile platforms, proxy configuration should be handled by flutter itself, so here the plugin just returns `null`. On desktop platforms this asks the embedder for the current proxy configuration.

The newly added `HttpieOverrides` class is set as an override for the main zone the app runs in. This way, all other plugins/libraries that use the `HttpClient` from `dart:http` will pick up on the proxy we've set.