### PR TITLE
🐛 Fix mention suggestions not clickable after newline

### DIFF
--- a/lib/services/text_account_autocompletion.dart
+++ b/lib/services/text_account_autocompletion.dart
@@ -15,7 +15,7 @@ class TextAccountAutocompletionService {
   }
 
   String autocompleteTextWithUsername(String text, String username){
-    String lastWord = text.split(' ').last;
+    String lastWord = text.split(RegExp(r'\s')).last;
 
     if(!lastWord.startsWith('@')){
       throw 'Tried to autocomplete text with username without @';


### PR DESCRIPTION
Fixes #386.

The auto-completer tried to split on `' '` and then checked if the last string result started with `@`. This failed if the `@` was at the start of a line since it was then preceded by a new line rather than a normal space.