### PR TITLE
Enable mention suggestions anywhere in the text

### DIFF
--- a/lib/pages/home/modals/create_post/create_post.dart
+++ b/lib/pages/home/modals/create_post/create_post.dart
@@ -486,11 +486,8 @@ class CreatePostModalState extends State<CreatePostModal> {
 
     debugLog('Autocompleting with username:$foundAccountUsername');
     setState(() {
-      _textController.text =
-          _textAccountAutocompletionService.autocompleteTextWithUsername(
-              _textController.text, foundAccountUsername);
-      _textController.selection =
-          TextSelection.collapsed(offset: _textController.text.length);
+      _textAccountAutocompletionService.autocompleteTextWithUsername(
+          _textController, foundAccountUsername);
     });
   }
 

--- a/lib/pages/home/modals/post_comment/post_comment_reply_expanded.dart
+++ b/lib/pages/home/modals/post_comment/post_comment_reply_expanded.dart
@@ -304,11 +304,8 @@ class OBPostCommentReplyExpandedModalState
 
     debugLog('Autocompleting with username:$foundAccountUsername');
     setState(() {
-      _textController.text =
-          _textAccountAutocompletionService.autocompleteTextWithUsername(
-              _textController.text, foundAccountUsername);
-      _textController.selection =
-          TextSelection.collapsed(offset: _textController.text.length);
+      _textAccountAutocompletionService.autocompleteTextWithUsername(
+          _textController, foundAccountUsername);
     });
   }
 

--- a/lib/pages/home/modals/post_comment/post_commenter_expanded.dart
+++ b/lib/pages/home/modals/post_comment/post_commenter_expanded.dart
@@ -232,11 +232,8 @@ class OBPostCommenterExpandedModalState
 
     debugLog('Autocompleting with username:$foundAccountUsername');
     setState(() {
-      _textController.text =
-          _textAccountAutocompletionService.autocompleteTextWithUsername(
-              _textController.text, foundAccountUsername);
-      _textController.selection =
-          TextSelection.collapsed(offset: _textController.text.length);
+      _textAccountAutocompletionService.autocompleteTextWithUsername(
+          _textController, foundAccountUsername);
     });
   }
 

--- a/lib/pages/home/pages/post_comments/widgets/post_commenter.dart
+++ b/lib/pages/home/pages/post_comments/widgets/post_commenter.dart
@@ -264,11 +264,8 @@ class OBPostCommenterState extends State<OBPostCommenter> {
 
     debugLog('Autocompleting with username:$foundAccountUsername');
     setState(() {
-      _textController.text =
-          _textAccountAutocompletionService.autocompleteTextWithUsername(
-              _textController.text, foundAccountUsername);
-      _textController.selection =
-          TextSelection.collapsed(offset: _textController.text.length);
+      _textAccountAutocompletionService.autocompleteTextWithUsername(
+          _textController, foundAccountUsername);
     });
   }
 

--- a/lib/services/text_account_autocompletion.dart
+++ b/lib/services/text_account_autocompletion.dart
@@ -4,13 +4,8 @@ class TextAccountAutocompletionService {
   TextAccountAutocompletionResult checkTextForAutocompletion(TextEditingController textController) {
     int cursorPosition = textController.selection.baseOffset;
 
-    //FIXME(komposten): No need to split the full string when we can just find the first "\s" before the cursorPosition.
     if (cursorPosition >= 0) {
-      String lastWord = textController.text
-          .substring(0, cursorPosition)
-          .replaceAll('\n', ' ')
-          .split(' ')
-          .last;
+      String lastWord = _getWordBeforeCursor(textController.text, cursorPosition);
 
       if (lastWord.startsWith('@')) {
         String searchQuery = lastWord.substring(1);
@@ -25,9 +20,7 @@ class TextAccountAutocompletionService {
   void autocompleteTextWithUsername(TextEditingController textController, String username){
     String text = textController.text;
     int cursorPosition = textController.selection.baseOffset;
-
-    //FIXME(komposten): No need to split the full string when we can just find the first "\s" before the cursorPosition.
-    String lastWord = text.substring(0, cursorPosition).split(RegExp(r'\s')).last;
+    String lastWord = _getWordBeforeCursor(text, cursorPosition);
 
     if(!lastWord.startsWith('@')){
       throw 'Tried to autocomplete text with username without @';
@@ -37,6 +30,15 @@ class TextAccountAutocompletionService {
     var newSelection = TextSelection.collapsed(offset: cursorPosition - lastWord.length + username.length + 1);
 
     textController.value = TextEditingValue(text: newText, selection: newSelection);
+  }
+
+  String _getWordBeforeCursor(String text, int cursorPosition) {
+    if (text.isNotEmpty) {
+      var start = text.lastIndexOf(RegExp(r'\s'), cursorPosition - 1);
+      return text.substring(start + 1, cursorPosition);
+    } else {
+      return text;
+    }
   }
 }
 

--- a/lib/services/text_account_autocompletion.dart
+++ b/lib/services/text_account_autocompletion.dart
@@ -2,26 +2,41 @@ import 'package:flutter/cupertino.dart';
 
 class TextAccountAutocompletionService {
   TextAccountAutocompletionResult checkTextForAutocompletion(TextEditingController textController) {
-    String lastWord = textController.text.replaceAll('\n', ' ').split(' ').last;
     int cursorPosition = textController.selection.baseOffset;
 
-    if (lastWord.startsWith('@') && cursorPosition == textController.text.length) {
-      String searchQuery = lastWord.substring(1);
-      return TextAccountAutocompletionResult(
-          isAutocompleting: true, autocompleteQuery: searchQuery);
-    } else {
-      return TextAccountAutocompletionResult(isAutocompleting: false);
+    //FIXME(komposten): No need to split the full string when we can just find the first "\s" before the cursorPosition.
+    if (cursorPosition >= 0) {
+      String lastWord = textController.text
+          .substring(0, cursorPosition)
+          .replaceAll('\n', ' ')
+          .split(' ')
+          .last;
+
+      if (lastWord.startsWith('@')) {
+        String searchQuery = lastWord.substring(1);
+        return TextAccountAutocompletionResult(
+            isAutocompleting: true, autocompleteQuery: searchQuery);
+      }
     }
+
+    return TextAccountAutocompletionResult(isAutocompleting: false);
   }
 
-  String autocompleteTextWithUsername(String text, String username){
-    String lastWord = text.split(RegExp(r'\s')).last;
+  void autocompleteTextWithUsername(TextEditingController textController, String username){
+    String text = textController.text;
+    int cursorPosition = textController.selection.baseOffset;
+
+    //FIXME(komposten): No need to split the full string when we can just find the first "\s" before the cursorPosition.
+    String lastWord = text.substring(0, cursorPosition).split(RegExp(r'\s')).last;
 
     if(!lastWord.startsWith('@')){
       throw 'Tried to autocomplete text with username without @';
     }
 
-    return text.substring(0, text.length - lastWord.length) + '@$username ';
+    var newText = text.substring(0, cursorPosition - lastWord.length) + '@$username' + text.substring(cursorPosition);
+    var newSelection = TextSelection.collapsed(offset: cursorPosition - lastWord.length + username.length + 1);
+
+    textController.value = TextEditingValue(text: newText, selection: newSelection);
   }
 }
 


### PR DESCRIPTION
Currently mention suggestions will only trigger if you write an @ at the very end of a post or comment input field. This PR enables the suggestion popup for mentions added _anywhere_ within the text.

**Example**
Write in a post or comment field:
> Hi,
> How are you?

Move the cursor between "Hi" and the comma, write a space and `@`, and suggestions should appear.