### PR TITLE
🐛 Fix exception when closing loading suggestion list

### DIFF
--- a/lib/widgets/contextual_account_search_box.dart
+++ b/lib/widgets/contextual_account_search_box.dart
@@ -67,6 +67,8 @@ class OBContextualAccountSearchBoxState
 
   @override
   void dispose() {
+    _searchParticipantsOperation?.cancel();
+    _getAllOperation?.cancel();
     super.dispose();
   }
 


### PR DESCRIPTION
Writing `@` and then erasing it before the suggestion list had loaded would eventually throw an exception. This happened because the suggestion list would finish loading and update its state after it had already been disposed.

Now `OBContextualAccountSearchBoxState` cancels the get and search operations before it is disposed.