### PR TITLE
Fix sharing + add video sharing

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -76,6 +76,11 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <data android:mimeType="text/*"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="video/*"/>
+            </intent-filter>
         </activity>
         <activity
                 android:name="com.yalantis.ucrop.UCropActivity"

--- a/android/app/src/main/java/com/example/openbook/MainActivity.java
+++ b/android/app/src/main/java/com/example/openbook/MainActivity.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.util.Log;
+import android.webkit.MimeTypeMap;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -125,8 +126,9 @@ public class MainActivity extends FlutterActivity {
 
     if (videoUri.getScheme().equals("file")) {
       result = videoUri;
-    } else {
-      File tempFile = createTemporaryFile("");
+    } else if (videoUri.getScheme().equals("content")){
+      String extension = getExtensionFromContentUri(videoUri);
+      File tempFile = createTemporaryFile("." + extension);
 
       try (InputStream in = this.getContentResolver().openInputStream(videoUri);
            OutputStream out = new FileOutputStream(tempFile)) {
@@ -143,6 +145,11 @@ public class MainActivity extends FlutterActivity {
     }
 
     return result;
+  }
+
+  private String getExtensionFromContentUri(Uri contentUri) {
+    String mime = this.getContentResolver().getType(contentUri);
+    return MimeTypeMap.getSingleton().getExtensionFromMimeType(mime);
   }
 
   private File createTemporaryFile(String extension) {

--- a/android/app/src/main/java/com/example/openbook/MainActivity.java
+++ b/android/app/src/main/java/com/example/openbook/MainActivity.java
@@ -9,6 +9,7 @@ import android.webkit.MimeTypeMap;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
@@ -78,50 +79,83 @@ public class MainActivity extends FlutterActivity {
       }
 
       Map<String, String> args = new HashMap<>();
-      if (intent.getType().startsWith("image/")) {
-        Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
-        uri = copyImageToTempFile(uri);
-        args.put("image", uri.toString());
-      } else if (intent.getType().startsWith("video/")) {
-        Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
-        uri = copyVideoToTempFileIfNeeded(uri);
-        if (uri != null) {
+
+      try {
+        if (intent.getType().startsWith("image/")) {
+          Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
+          uri = copyImageToTempFile(uri);
+          args.put("image", uri.toString());
+        } else if (intent.getType().startsWith("video/")) {
+          Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
+          uri = copyVideoToTempFileIfNeeded(uri);
           args.put("video", uri.toString());
+        } else if (intent.getType().startsWith("text/")) {
+          args.put("text", intent.getStringExtra(Intent.EXTRA_TEXT));
         } else {
+          Log.w(getClass().getSimpleName(), "unknown intent type \"" + intent.getType() + "\" received, ignoring");
           return;
         }
-      } else if (intent.getType().startsWith("text/")) {
-        args.put("text", intent.getStringExtra(Intent.EXTRA_TEXT));
-      } else {
-        Log.w(getClass().getSimpleName(), "unknown intent type \"" + intent.getType() + "\" received, ignoring");
-        return;
+      } catch (KeyedException e) {
+        String msg = String.format("an exception occurred while receiving share of type %s" +
+                "%n %s", intent.getType(), e.getCause() != null ? e.getCause().toString() : e.toString());
+        String errorTextKey = "";
+
+        switch (e.getKey()) {
+          case TempCreationFailed:
+          case WriteTempFailed:
+          case WriteTempMissing:
+            errorTextKey = "error__receive_share_temp_write_failed";
+            break;
+          case WriteTempDenied:
+          case TempCreationDenied:
+            errorTextKey = "error__receive_share_temp_write_denied";
+            break;
+          case UriSchemeNotSupported:
+            errorTextKey = "error__receive_share_invalid_uri_scheme";
+            break;
+          case ReadFileMissing:
+            errorTextKey = "error__receive_share_file_not_found";
+            break;
+        }
+
+        args.put("error", errorTextKey);
+        Log.w(getClass().getSimpleName(), msg);
       }
+
       Log.i(getClass().getSimpleName(), "sending intent to flutter");
       eventSink.success(args);
     }
   }
 
-  private Uri copyImageToTempFile(Uri imageUri) {
+  private Uri copyImageToTempFile(Uri imageUri) throws KeyedException {
+    byte[] data;
     try {
-      byte[] data;
       if (imageUri.getScheme().equals("content")) {
         data = ImageConverter.convertImageData(this.getContentResolver().openInputStream(imageUri), ImageConverter.TargetFormat.JPEG);
-      } else {
+      } else if (imageUri.getScheme().equals("file")) {
         data = ImageConverter.convertImageDataFile(new File(imageUri.getPath()), ImageConverter.TargetFormat.JPEG);
+      } else {
+        throw new KeyedException(KeyedException.Key.UriSchemeNotSupported, imageUri.getScheme(), null);
       }
-
-      File imageFile = createTemporaryFile(".jpeg");
-      FileOutputStream fileOutput = new FileOutputStream(imageFile);
-      fileOutput.write(data);
-      fileOutput.close();
-
-      return Uri.fromFile(imageFile);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    } catch (FileNotFoundException e) {
+      throw new KeyedException(KeyedException.Key.ReadFileMissing, e);
     }
+
+    File imageFile = createTemporaryFile(".jpeg");
+    try (FileOutputStream fileOutput = new FileOutputStream(imageFile)) {
+      fileOutput.write(data);
+    } catch (FileNotFoundException e) {
+      throw new KeyedException(KeyedException.Key.WriteTempMissing, e);
+    } catch (IOException e) {
+      throw new KeyedException(KeyedException.Key.WriteTempFailed, e);
+    } catch (SecurityException e) {
+      throw new KeyedException(KeyedException.Key.WriteTempDenied, e);
+    }
+
+    return Uri.fromFile(imageFile);
   }
 
-  private Uri copyVideoToTempFileIfNeeded(Uri videoUri) {
+  private Uri copyVideoToTempFileIfNeeded(Uri videoUri) throws KeyedException {
     Uri result = null;
 
     if (videoUri.getScheme().equals("file")) {
@@ -130,18 +164,29 @@ public class MainActivity extends FlutterActivity {
       String extension = getExtensionFromContentUri(videoUri);
       File tempFile = createTemporaryFile("." + extension);
 
-      try (InputStream in = this.getContentResolver().openInputStream(videoUri);
-           OutputStream out = new FileOutputStream(tempFile)) {
-        byte[] data = new byte[1024];
-        int length;
-        while ((length = in.read(data)) > 0) {
-          out.write(data, 0, length);
-        }
+      try (InputStream in = this.getContentResolver().openInputStream(videoUri)) {
+        try (OutputStream out = new FileOutputStream(tempFile)) {
+          byte[] data = new byte[1024];
+          int length;
+          while ((length = in.read(data)) > 0) {
+            out.write(data, 0, length);
+          }
 
-        result = Uri.fromFile(tempFile);
+          result = Uri.fromFile(tempFile);
+        } catch (FileNotFoundException e) {
+          throw new KeyedException(KeyedException.Key.WriteTempMissing, e);
+        } catch (IOException e) {
+          throw new KeyedException(KeyedException.Key.WriteTempFailed, e);
+        } catch (SecurityException e) {
+          throw new KeyedException(KeyedException.Key.WriteTempDenied, e);
+        }
+      } catch (FileNotFoundException e) {
+        throw new KeyedException(KeyedException.Key.ReadFileMissing, e);
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        //Exception when closing the input stream. Ignore.
       }
+    } else {
+      throw new KeyedException(KeyedException.Key.UriSchemeNotSupported, videoUri.getScheme(), null);
     }
 
     return result;
@@ -152,12 +197,53 @@ public class MainActivity extends FlutterActivity {
     return MimeTypeMap.getSingleton().getExtensionFromMimeType(mime);
   }
 
-  private File createTemporaryFile(String extension) {
+  private File createTemporaryFile(String extension) throws KeyedException {
+    String name = UUID.randomUUID().toString();
+
     try {
-      String name = UUID.randomUUID().toString();
       return File.createTempFile(name, extension, this.getExternalFilesDir(Environment.DIRECTORY_PICTURES));
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new KeyedException(KeyedException.Key.TempCreationFailed, e);
+    } catch (SecurityException e) {
+      throw new KeyedException(KeyedException.Key.TempCreationDenied, e);
     }
+  }
+}
+
+class KeyedException extends Exception {
+  public enum Key {
+    TempCreationFailed("Failed to create temporary file."),
+    TempCreationDenied(TempCreationFailed.message),
+    WriteTempDenied("Failed to write to temporary file."),
+    WriteTempFailed(WriteTempDenied.message),
+    WriteTempMissing(WriteTempDenied.message),
+    ReadFileMissing("Failed to read the shared file."),
+    UriSchemeNotSupported("Unsupported UR scheme: ");
+
+    private String message;
+
+    private Key(String msg) {
+      message = msg;
+    }
+  }
+  private final Key key;
+
+  public KeyedException(Key key, Throwable cause) {
+    super(cause);
+    this.key = key;
+  }
+
+  public KeyedException(Key key, String message, Throwable cause) {
+    super(message, cause);
+    this.key = key;
+  }
+
+  public Key getKey() {
+    return key;
+  }
+
+  @Override
+  public String getMessage() {
+    return key.message + super.getMessage();
   }
 }

--- a/assets/i18n/en/error.arb
+++ b/assets/i18n/en/error.arb
@@ -4,6 +4,26 @@
     "type": "text",
     "placeholders": {}
   },
+  "receive_share_temp_write_failed": "Failed to copy shared file to temporary location",
+  "@receive_share_temp_write_failed": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "receive_share_temp_write_denied": "Denied permission to copy shared file to temporary location",
+  "@receive_share_temp_write_denied": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "receive_share_invalid_uri_scheme": "Failed to receive share",
+  "@receive_share_invalid_uri_scheme": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "receive_share_file_not_found": "Shared file could not be found",
+  "@receive_share_file_not_found": {
+    "type": "text",
+    "placeholders": {}
+  },
   "no_internet_connection": "No internet connection",
   "@no_internet_connection": {
     "type": "text",

--- a/lib/pages/home/home.dart
+++ b/lib/pages/home/home.dart
@@ -139,8 +139,9 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
   void onShare(Share share) async {
     String text;
     File image;
-    if (share.path != null) {
-      image = File.fromUri(Uri.parse(share.path));
+    File video;
+    if (share.image != null) {
+      image = File.fromUri(Uri.parse(share.image));
       image = await _imagePickerService.processImage(image);
       if (!await _validationService.isImageAllowedSize(
           image, OBImageType.post)) {
@@ -148,6 +149,15 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
             _validationService.getAllowedImageSize(OBImageType.post) ~/ 1048576;
         _toastService.error(
             message: 'Image too large (limit: $limit MB)', context: context);
+        return;
+      }
+    }
+    if (share.video != null) {
+      video = File.fromUri(Uri.parse(share.video));
+      if (!await _validationService.isVideoAllowedSize(video)) {
+        int limit = _validationService.getAllowedVideoSize() ~/ 1048576;
+        _toastService.error(
+            message: 'Video too large (limit: $limit MB)', context: context);
         return;
       }
     }
@@ -162,7 +172,7 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
       }
     }
 
-    if (await _timelinePageController.createPost(text: text, image: image)) {
+    if (await _timelinePageController.createPost(text: text, image: image, video: video)) {
       _timelinePageController.popUntilFirstRoute();
       _navigateToTab(OBHomePageTabs.timeline);
     }

--- a/lib/pages/home/home.dart
+++ b/lib/pages/home/home.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:Okuna/models/push_notification.dart';
 import 'package:Okuna/pages/home/lib/poppable_page_controller.dart';
 import 'package:Okuna/services/intercom.dart';
+import 'package:Okuna/services/localization.dart';
 import 'package:Okuna/services/push_notifications/push_notifications.dart';
 import 'package:Okuna/models/user.dart';
 import 'package:Okuna/pages/home/pages/communities/communities.dart';
@@ -51,6 +52,7 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
   ValidationService _validationService;
   MediaService _imagePickerService;
   UserPreferencesService _userPreferencesService;
+  LocalizationService _localizationService;
 
   int _currentIndex;
   int _lastIndex;
@@ -117,6 +119,7 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
       _validationService = openbookProvider.validationService;
       _imagePickerService = openbookProvider.mediaPickerService;
       _userPreferencesService = openbookProvider.userPreferencesService;
+      _localizationService = openbookProvider.localizationService;
       _bootstrap();
       _needsBootstrap = false;
     }
@@ -140,6 +143,16 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
     String text;
     File image;
     File video;
+    if (share.error != null) {
+      _toastService.error(
+          message: _localizationService.trans(share.error),
+          context: context);
+      if (share.error == 'uriSchemeNotSupported') {
+        throw share.error;
+      }
+      return;
+    }
+
     if (share.image != null) {
       image = File.fromUri(Uri.parse(share.image));
       image = await _imagePickerService.processImage(image);
@@ -152,6 +165,7 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
         return;
       }
     }
+
     if (share.video != null) {
       video = File.fromUri(Uri.parse(share.video));
       if (!await _validationService.isVideoAllowedSize(video)) {
@@ -161,6 +175,7 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
         return;
       }
     }
+
     if (share.text != null) {
       text = share.text;
       if (!_validationService.isPostTextAllowedLength(text)) {

--- a/lib/pages/home/home.dart
+++ b/lib/pages/home/home.dart
@@ -161,7 +161,8 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
         return;
       }
     }
-    _modalService.openCreatePost(context: context, text: text, image: image);
+
+    _timelinePageController.createPost(text: text, image: image);
   }
 
   Widget _getPageForTabIndex(int index) {

--- a/lib/pages/home/home.dart
+++ b/lib/pages/home/home.dart
@@ -162,7 +162,10 @@ class OBHomePageState extends ReceiveShareState<OBHomePage>
       }
     }
 
-    _timelinePageController.createPost(text: text, image: image);
+    if (await _timelinePageController.createPost(text: text, image: image)) {
+      _timelinePageController.popUntilFirstRoute();
+      _navigateToTab(OBHomePageTabs.timeline);
+    }
   }
 
   Widget _getPageForTabIndex(int index) {

--- a/lib/pages/home/modals/save_post/create_post.dart
+++ b/lib/pages/home/modals/save_post/create_post.dart
@@ -41,10 +41,11 @@ class OBSavePostModal extends StatefulWidget {
   final Community community;
   final String text;
   final File image;
+  final File video;
   final Post post;
 
   const OBSavePostModal(
-      {Key key, this.community, this.text, this.image, this.post})
+      {Key key, this.community, this.text, this.image, this.video, this.post})
       : super(key: key);
 
   @override
@@ -138,6 +139,9 @@ class OBSavePostModalState extends State<OBSavePostModal> {
         ));
       if (widget.image != null) {
         _setPostImageFile(widget.image);
+      }
+      if (widget.video != null) {
+        _setPostVideoFile(widget.video);
       }
     }
 

--- a/lib/pages/home/pages/timeline/timeline.dart
+++ b/lib/pages/home/pages/timeline/timeline.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:Okuna/models/circle.dart';
 import 'package:Okuna/models/follows_list.dart';
@@ -112,15 +113,7 @@ class OBTimelinePageState extends State<OBTimelinePage> {
                       label: _localizationService.post__create_new_post_label,
                       child: OBFloatingActionButton(
                           type: OBButtonType.primary,
-                          onPressed: () async {
-                            OBNewPostData createPostData = await _modalService
-                                .openCreatePost(context: context);
-                            if (createPostData != null) {
-                              addNewPostData(createPostData);
-                              _timelinePostsStreamController.scrollToTop(
-                                  skipRefresh: true);
-                            }
-                          },
+                          onPressed: _onCreatePost,
                           child: const OBIcon(OBIcons.createPost,
                               size: OBIconSize.large, color: Colors.white))))
             ],
@@ -201,6 +194,16 @@ class OBTimelinePageState extends State<OBTimelinePage> {
         .posts;
 
     return morePosts;
+  }
+
+  Future<void> _onCreatePost({String text, File image}) async {
+    OBNewPostData createPostData = await _modalService
+        .openCreatePost(text: text, image: image, context: context);
+    if (createPostData != null) {
+      addNewPostData(createPostData);
+      _timelinePostsStreamController.scrollToTop(
+          skipRefresh: true);
+    }
   }
 
   Future<void> setFilters(
@@ -284,6 +287,10 @@ class OBTimelinePageController extends PoppablePageController {
 
   List<FollowsList> getFilteredFollowsLists() {
     return _state.getFilteredFollowsLists();
+  }
+
+  Future<void> createPost({String text, File image}) {
+    return _state._onCreatePost(text: text, image: image);
   }
 
   void scrollToTop() {

--- a/lib/pages/home/pages/timeline/timeline.dart
+++ b/lib/pages/home/pages/timeline/timeline.dart
@@ -196,14 +196,18 @@ class OBTimelinePageState extends State<OBTimelinePage> {
     return morePosts;
   }
 
-  Future<void> _onCreatePost({String text, File image}) async {
+  Future<bool> _onCreatePost({String text, File image}) async {
     OBNewPostData createPostData = await _modalService
         .openCreatePost(text: text, image: image, context: context);
     if (createPostData != null) {
       addNewPostData(createPostData);
       _timelinePostsStreamController.scrollToTop(
           skipRefresh: true);
+
+      return true;
     }
+
+    return false;
   }
 
   Future<void> setFilters(
@@ -289,7 +293,7 @@ class OBTimelinePageController extends PoppablePageController {
     return _state.getFilteredFollowsLists();
   }
 
-  Future<void> createPost({String text, File image}) {
+  Future<bool> createPost({String text, File image}) {
     return _state._onCreatePost(text: text, image: image);
   }
 

--- a/lib/pages/home/pages/timeline/timeline.dart
+++ b/lib/pages/home/pages/timeline/timeline.dart
@@ -196,9 +196,9 @@ class OBTimelinePageState extends State<OBTimelinePage> {
     return morePosts;
   }
 
-  Future<bool> _onCreatePost({String text, File image}) async {
+  Future<bool> _onCreatePost({String text, File image, File video}) async {
     OBNewPostData createPostData = await _modalService
-        .openCreatePost(text: text, image: image, context: context);
+        .openCreatePost(text: text, image: image, video: video, context: context);
     if (createPostData != null) {
       addNewPostData(createPostData);
       _timelinePostsStreamController.scrollToTop(
@@ -293,8 +293,8 @@ class OBTimelinePageController extends PoppablePageController {
     return _state.getFilteredFollowsLists();
   }
 
-  Future<bool> createPost({String text, File image}) {
-    return _state._onCreatePost(text: text, image: image);
+  Future<bool> createPost({String text, File image, File video}) {
+    return _state._onCreatePost(text: text, image: image, video: video);
   }
 
   void scrollToTop() {

--- a/lib/plugins/share/share.dart
+++ b/lib/plugins/share/share.dart
@@ -2,21 +2,25 @@ class Share {
   static const String IMAGE = 'image';
   static const String VIDEO = 'video';
   static const String TEXT = 'text';
+  static const String ERROR = 'error';
 
   final String image;
   final String video;
   final String text;
+  final String error;
 
   const Share({
     this.image,
     this.video,
-    this.text
+    this.text,
+    this.error
   });
 
   static Share fromReceived(Map received) {
     String text;
     String image;
     String video;
+    String error;
     if (received.containsKey(TEXT)) {
       text = received[TEXT];
     }
@@ -26,6 +30,9 @@ class Share {
     if (received.containsKey(VIDEO)) {
       video = received[VIDEO];
     }
-    return Share(image: image, video: video, text: text);
+    if (received.containsKey(ERROR)) {
+      error = received[ERROR];
+    }
+    return Share(image: image, video: video, text: text, error: error);
   }
 }

--- a/lib/plugins/share/share.dart
+++ b/lib/plugins/share/share.dart
@@ -1,24 +1,31 @@
 class Share {
-  static const String PATH = 'path';
+  static const String IMAGE = 'image';
+  static const String VIDEO = 'video';
   static const String TEXT = 'text';
 
-  final String path;
+  final String image;
+  final String video;
   final String text;
 
   const Share({
-    this.path,
-    this.text,
+    this.image,
+    this.video,
+    this.text
   });
 
   static Share fromReceived(Map received) {
     String text;
-    String path;
+    String image;
+    String video;
     if (received.containsKey(TEXT)) {
       text = received[TEXT];
     }
-    if (received.containsKey(PATH)) {
-      path = received[PATH];
+    if (received.containsKey(IMAGE)) {
+      image = received[IMAGE];
     }
-    return Share(path: path, text: text);
+    if (received.containsKey(VIDEO)) {
+      video = received[VIDEO];
+    }
+    return Share(image: image, video: video, text: text);
   }
 }

--- a/lib/services/localization.dart
+++ b/lib/services/localization.dart
@@ -788,6 +788,26 @@ class LocalizationService {
     return Intl.message("Unknown error", name: 'error__unknown_error');
   }
 
+  String get error__receive_share_temp_write_failed {
+    return Intl.message('Failed to copy shared file to temporary location',
+        name: 'error__receive_share_temp_write_failed');
+  }
+
+  String get error__receive_share_temp_write_denied {
+    return Intl.message('Denied permission to copy shared file to temporary location',
+        name: 'error__receive_share_temp_write_denied');
+  }
+
+  String get error__receive_share_invalid_uri_scheme {
+    return Intl.message('Failed to receive share',
+        name: 'error__receive_share_invalid_uri_scheme');
+  }
+
+  String get error__receive_share_file_not_found {
+    return Intl.message('Shared file could not be found',
+        name: 'error__receive_share_file_not_found');
+  }
+
   String get error__no_internet_connection {
     return Intl.message("No internet connection",
         name: 'error__no_internet_connection');

--- a/lib/services/modal_service.dart
+++ b/lib/services/modal_service.dart
@@ -48,7 +48,8 @@ class ModalService {
       {@required BuildContext context,
       Community community,
       String text,
-      File image}) async {
+      File image,
+      File video}) async {
     OBNewPostData createPostData =
         await Navigator.of(context, rootNavigator: true)
             .push(CupertinoPageRoute<OBNewPostData>(
@@ -59,6 +60,7 @@ class ModalService {
                       community: community,
                       text: text,
                       image: image,
+                      video: video,
                     ),
                   );
                 }));

--- a/lib/widgets/new_post_data_uploader.dart
+++ b/lib/widgets/new_post_data_uploader.dart
@@ -53,6 +53,7 @@ class OBNewPostDataUploaderState extends State<OBNewPostDataUploader>
   Timer _checkPostStatusTimer;
 
   CancelableOperation _getPostStatusOperation;
+  CancelableOperation _uploadPostOperation;
   OBNewPostData _data;
 
   @override
@@ -67,7 +68,8 @@ class OBNewPostDataUploaderState extends State<OBNewPostDataUploader>
   void dispose() {
     super.dispose();
     _ensurePostStatusTimerIsCancelled();
-    if (_getPostStatusOperation != null) _getPostStatusOperation.cancel();
+    _getPostStatusOperation?.cancel();
+    _uploadPostOperation?.cancel();
   }
 
   @override
@@ -129,7 +131,11 @@ class OBNewPostDataUploaderState extends State<OBNewPostDataUploader>
   }
 
   void _bootstrap() {
-    _uploadPost();
+    _startUpload();
+  }
+
+  void _startUpload() {
+    _uploadPostOperation = CancelableOperation.fromFuture(_uploadPost());
   }
 
   Future _uploadPost() async {
@@ -380,8 +386,7 @@ class OBNewPostDataUploaderState extends State<OBNewPostDataUploader>
         _status == OBPostUploaderStatus.addingPostMedia) return;
 
     debugLog('Retrying');
-
-    _uploadPost();
+    _startUpload();
   }
 
   void _onWantsToCancel() async {
@@ -423,15 +428,19 @@ class OBNewPostDataUploaderState extends State<OBNewPostDataUploader>
   }
 
   void _setStatus(OBPostUploaderStatus status) {
-    setState(() {
-      _status = status;
-    });
+    if (mounted) {
+      setState(() {
+        _status = status;
+      });
+    }
   }
 
   void _setStatusMessage(String statusMessage) {
-    setState(() {
-      _statusMessage = statusMessage;
-    });
+    if (mounted) {
+      setState(() {
+        _statusMessage = statusMessage;
+      });
+    }
   }
 
   void _ensurePostStatusTimerIsCancelled() {


### PR DESCRIPTION
## Sharing bug
Sharing text or images from another app will now trigger the same "create post flow" as when you create a post from the timeline. Additionally, if the user has navigated to another tab or page/route, they will be sent back to the timeline (at least they will be when the "switching tabs only works once" bug gets fixed). This only triggers if they actually create the post; cancelling the post modal will not change tab or pop any routes.

Issues to fix:
- [x] Sometimes two OBNewPostDataUploaders are created when a post is created via the share flow. This appears to only happen if the user is not at the top of the timeline and they have another route open on top of it (e.g. a post comment section). The result is that one of the uploaders crashes (tries to set its state after being disposed), while the other finishes uploading the post. The end user won't notice anything.
- [ ] `popUntilFirstRoute` doesn't close modals created on the root navigator.

## Video sharing
You can now share videos to Okuna on Android.