### PR TITLE
🐛 Fix some URLs (e.g. https://bandcamp.com) not getting previewed

### DIFF
--- a/lib/services/link_preview.dart
+++ b/lib/services/link_preview.dart
@@ -57,7 +57,8 @@ class LinkPreviewService {
     }));
 
     if (matches.length > 0) {
-      String urlMimeType = _utilsService.geFileNameMimeType(matches.first);
+      Uri url = Uri.parse(matches.first);
+      String urlMimeType = _utilsService.geFileNameMimeType(url.path);
       if (urlMimeType != null) {
         String urlFirstType = urlMimeType.split('/').first;
         if (urlFirstType != 'image' && urlFirstType != 'text') return null;


### PR DESCRIPTION
This PR fixes link previews not appearing for URLs without path components. For example, `https://example.com` will currently not show a preview, but `https://example.com/` will.

Previously the full preview URL was passed to `getFileNameMimeType()`. This worked fine for URLs with paths (e.g. `https://example.com/path/to/file.png`). However, we get weird results for URLs without paths, like `https://example.com`. In this case it would look up a MIME type for ".com", and since the resulting MIME type is `application/ms...` (.com files are a type of executable on Windows) it ends up not displaying a preview.

With this PR we instead first extract the path component of the URL and then check for a MIME type in the path.