### PR TITLE
Check for video widget state

### DIFF
--- a/lib/widgets/video_player/video_player.dart
+++ b/lib/widgets/video_player/video_player.dart
@@ -175,9 +175,11 @@ class OBVideoPlayerState extends State<OBVideoPlayer> {
     if (widget.controller._attemptedToPlayWhileNotReady)
       _playerController.play();
 
-    setState(() {
-      _videoInitialized = true;
-    });
+    if (mounted) {
+      setState(() {
+        _videoInitialized = true;
+      });
+    }
   }
 
   void _bootstrap() async {


### PR DESCRIPTION
This PR adds a missing check that the video widget is mounted before setting the state. Without this fix, `setState` throws an exception if the video has been unmounted while loading, for example when scrolling very fast through the app.