### PR TITLE
🐛 Fix adding multiple GIFs to a post.

### DIFF
--- a/lib/pages/home/modals/save_post/create_post.dart
+++ b/lib/pages/home/modals/save_post/create_post.dart
@@ -414,9 +414,9 @@ class OBSavePostModalState extends OBContextualSearchBoxState<OBSavePostModal> {
             if (pickedPhoto != null) {
               bool photoIsGif = await _mediaService.isGif(pickedPhoto);
               if (photoIsGif) {
-                File gifVideo =
-                    await _mediaService.convertGifToVideo(pickedPhoto);
-                _setPostVideoFile(gifVideo);
+                _mediaService.convertGifToVideo(pickedPhoto).then(
+                    (file) => _setPostVideoFile(file),
+                    onError: (error, trace) => throw error);
               } else {
                 _setPostImageFile(pickedPhoto);
               }
@@ -551,16 +551,19 @@ class OBSavePostModalState extends OBContextualSearchBoxState<OBSavePostModal> {
     if (video != null) {
       final isGif = await _mediaService.isGif(video);
       if (isGif) {
-        var operation = CancelableOperation.fromFuture(
-            _mediaService.convertGifToVideo(video));
+        var conversionOp = _mediaService.convertGifToVideo(video);
 
-        operation.then((value) {
-          if (!operation.isCanceled && value != null) {
+        conversionOp.then((value) {
+          if (!conversionOp.isCanceled && value != null) {
             _setPostVideoFile(value);
+          }
+        }, onError: (error, trace) {
+          if (!conversionOp.isCanceled) {
+            print(error);
           }
         });
 
-        return operation;
+        return conversionOp;
       } else {
         _setPostVideoFile(video);
       }

--- a/lib/pages/home/modals/save_post/create_post.dart
+++ b/lib/pages/home/modals/save_post/create_post.dart
@@ -460,6 +460,10 @@ class OBSavePostModalState extends OBContextualSearchBoxState<OBSavePostModal> {
   }
 
   void _setPostImageFile(File image) {
+    if (!mounted) {
+      return;
+    }
+
     setState(() {
       this._postImageFile = image;
       _hasImage = true;
@@ -486,6 +490,10 @@ class OBSavePostModalState extends OBContextualSearchBoxState<OBSavePostModal> {
   }
 
   void _setPostVideoFile(File video) {
+    if (!mounted) {
+      return;
+    }
+
     setState(() {
       this._postVideoFile = video;
       _hasVideo = true;

--- a/lib/services/share.dart
+++ b/lib/services/share.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:async/async.dart';
 import 'package:Okuna/plugins/share/share.dart';
 import 'package:Okuna/services/localization.dart';
 import 'package:Okuna/services/toast.dart';
 import 'package:Okuna/services/validation.dart';
+import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -20,9 +20,11 @@ class ShareService {
   LocalizationService _localizationService;
 
   StreamSubscription _shareReceiveSubscription;
-  List<Future<dynamic> Function({String text, File image, File video})> _subscribers;
+  List<Future<dynamic> Function({String text, File image, File video})>
+      _subscribers;
 
   Share _queuedShare;
+  bool _isProcessingShare = false;
   CancelableOperation _activeShareOperation;
 
   BuildContext _context;
@@ -67,41 +69,51 @@ class ShareService {
   ///
   /// If a [CancelableOperation] is returned, it _must_ handle cancellation
   /// properly.
-  void subscribe(Future<dynamic> Function({String text, File image, File video}) onShare) {
+  void subscribe(
+      Future<dynamic> Function({String text, File image, File video}) onShare) {
     _subscribers.add(onShare);
 
     if (_subscribers.length == 1) {
-      _emptyQueue();
+      _processQueuedShare();
     }
   }
 
-  void unsubscribe(Future<dynamic> Function({String text, File image, File video}) subscriber) {
+  void unsubscribe(
+      Future<dynamic> Function({String text, File image, File video})
+          subscriber) {
     _subscribers.remove(subscriber);
   }
 
-  Future<void> _emptyQueue() async {
-    var share = _queuedShare;
-    _queuedShare = null;
-    await _onShare(share);
-  }
-
   void _onReceiveShare(dynamic shared) async {
-    var share = Share.fromReceived(shared);
+    _queuedShare = Share.fromReceived(shared);
 
-    if (_subscribers.isEmpty) {
-      _queuedShare = share;
-    } else {
-      await _onShare(share);
+    if (_subscribers.isNotEmpty && !_isProcessingShare) {
+      _processQueuedShare();
     }
   }
 
-  Future<bool> _onShare(Share share) async {
+  Future<void> _processQueuedShare() async {
+    if (_queuedShare != null) {
+      var share = _queuedShare;
+      _queuedShare = null;
+
+      _isProcessingShare = true;
+      await _onShare(share);
+      _isProcessingShare = false;
+
+      // Recurse since a new share might have came in while the last was being processed.
+      _processQueuedShare();
+    }
+  }
+
+  Future<void> _onShare(Share share) async {
     String text;
     File image;
     File video;
 
     if (_activeShareOperation != null) {
       _activeShareOperation.cancel();
+      _activeShareOperation = null;
     }
 
     if (share.error != null) {
@@ -110,7 +122,7 @@ class ShareService {
       if (share.error.contains('uri_scheme')) {
         throw share.error;
       }
-      return true;
+      return;
     }
 
     if (share.image != null) {
@@ -120,7 +132,7 @@ class ShareService {
           image, OBImageType.post)) {
         _showFileTooLargeToast(
             _validationService.getAllowedImageSize(OBImageType.post));
-        return true;
+        return;
       }
     }
 
@@ -129,7 +141,7 @@ class ShareService {
 
       if (!await _validationService.isVideoAllowedSize(video)) {
         _showFileTooLargeToast(_validationService.getAllowedVideoSize());
-        return true;
+        return;
       }
     }
 
@@ -140,7 +152,7 @@ class ShareService {
             message:
                 'Text too long (limit: ${ValidationService.POST_MAX_LENGTH} characters)',
             context: _context);
-        return true;
+        return;
       }
     }
 
@@ -151,20 +163,17 @@ class ShareService {
       // a CancelableOperation.
       if (subResult is CancelableOperation) {
         _activeShareOperation = subResult;
-        return true;
-      }
-      else if (subResult is bool && subResult) {
-        return true;
+        break;
+      } else if (subResult == true) {
+        break;
       }
     }
-
-    return false;
   }
 
   Future _showFileTooLargeToast(int limitInBytes) async {
     _toastService.error(
-        message: _localizationService.image_picker__error_too_large(
-            limitInBytes ~/ 1048576),
+        message: _localizationService
+            .image_picker__error_too_large(limitInBytes ~/ 1048576),
         context: _context);
   }
 }


### PR DESCRIPTION
If a user opens a GIF keyboard and taps multiple GIFs in quick succession, all tapped GIFs would be added to the post. Now previous operations are cancelled for each new tap, so only the last tap will count.