### PR TITLE
🐛 Fix invisible staff page for private communities

### DIFF
--- a/lib/pages/home/pages/community/community.dart
+++ b/lib/pages/home/pages/community/community.dart
@@ -73,9 +73,15 @@ class OBCommunityPageState extends State<OBCommunityPage>
       _localizationService = openbookProvider.localizationService;
       _needsBootstrap = false;
 
-      // Refresh the community to make sure the model contains all relevant
-      // community information (like admins and moderators).
-      _refreshCommunity();
+      // If the user doesn't have permission to view the community we need to
+      // manually trigger a refresh here to make sure the model contains all
+      // relevant community information (like admins and moderators).
+      //
+      // If the user can see the content, a refresh will be triggered
+      // automatically by the OBPostsStream.
+      if (!_userCanSeeCommunityContent(_community)) {
+        _refreshCommunity();
+      }
     }
 
     return CupertinoPageScaffold(
@@ -95,16 +101,7 @@ class OBCommunityPageState extends State<OBCommunityPage>
                         AsyncSnapshot<Community> snapshot) {
                       Community latestCommunity = snapshot.data;
 
-                      bool communityIsPrivate = latestCommunity.isPrivate();
-
-                      User loggedInUser = _userService.getLoggedInUser();
-                      bool userIsMember =
-                          latestCommunity.isMember(loggedInUser);
-
-                      bool userCanSeeCommunityContent =
-                          !communityIsPrivate || userIsMember;
-
-                      return userCanSeeCommunityContent
+                      return _userCanSeeCommunityContent(latestCommunity)
                           ? _buildCommunityContent()
                           : _buildPrivateCommunityContent();
                     }),
@@ -112,6 +109,15 @@ class OBCommunityPageState extends State<OBCommunityPage>
             ],
           ),
         ));
+  }
+
+  bool _userCanSeeCommunityContent(Community community) {
+    bool communityIsPrivate = community.isPrivate();
+
+    User loggedInUser = _userService.getLoggedInUser();
+    bool userIsMember = community.isMember(loggedInUser);
+
+    return !communityIsPrivate || userIsMember;
   }
 
   Widget _buildCommunityContent() {

--- a/lib/pages/home/pages/community/community.dart
+++ b/lib/pages/home/pages/community/community.dart
@@ -72,6 +72,10 @@ class OBCommunityPageState extends State<OBCommunityPage>
       _userService = openbookProvider.userService;
       _localizationService = openbookProvider.localizationService;
       _needsBootstrap = false;
+
+      // Refresh the community to make sure the model contains all relevant
+      // community information (like admins and moderators).
+      _refreshCommunity();
     }
 
     return CupertinoPageScaffold(

--- a/lib/pages/home/pages/community/pages/community_staff/community_staff.dart
+++ b/lib/pages/home/pages/community/pages/community_staff/community_staff.dart
@@ -17,7 +17,8 @@ class OBCommunityStaffPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    LocalizationService localizationService = OpenbookProvider.of(context).localizationService;
+    LocalizationService localizationService =
+        OpenbookProvider.of(context).localizationService;
 
     return OBCupertinoPageScaffold(
       navigationBar: OBThemedNavigationBar(
@@ -31,6 +32,7 @@ class OBCommunityStaffPage extends StatelessWidget {
             return SingleChildScrollView(
               physics: const ClampingScrollPhysics(),
               child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: <Widget>[
                   OBCommunityAdministrators(community),
                   OBCommunityModerators(community),


### PR DESCRIPTION
Tapping "Staff" on a private community you're not a member of will open an invisible staff page, which still captures gestures and must be dismissed before the app can be used again. This PR simply gives the empty staff page a background (or rather, gives it a non-zero width).

Note: It shouldn't be possible for a community to have both `community.administrators` and `community.moderators` set to null (that's another bug, possibly in the API). So this "empty staff page" situation shouldn't actually happen but in case it does it's better to have a blank page than an invisible one.