### PR TITLE
Feature/display hashtag casing

### DIFF
--- a/lib/pages/home/pages/hashtag/hashtag.dart
+++ b/lib/pages/home/pages/hashtag/hashtag.dart
@@ -11,8 +11,10 @@ import 'package:flutter/material.dart';
 class OBHashtagPage extends StatefulWidget {
   final OBHashtagPageController controller;
   final Hashtag hashtag;
+  final String rawHashtagName;
 
-  const OBHashtagPage({Key key, this.controller, this.hashtag})
+  const OBHashtagPage(
+      {Key key, this.controller, this.hashtag, this.rawHashtagName})
       : super(key: key);
 
   @override
@@ -47,9 +49,9 @@ class OBHashtagPageState extends State<OBHashtagPage> {
     return CupertinoPageScaffold(
         backgroundColor: Color.fromARGB(0, 0, 0, 0),
         navigationBar: OBHashtagNavBar(
-          key: Key('navBarHeader_${_hashtag.name}'),
-          hashtag: _hashtag,
-        ),
+            key: Key('navBarHeader_${_hashtag.name}'),
+            hashtag: _hashtag,
+            rawHashtagName: widget.rawHashtagName),
         child: OBPrimaryColorContainer(
           child: Column(
             mainAxisSize: MainAxisSize.max,
@@ -60,8 +62,7 @@ class OBHashtagPageState extends State<OBHashtagPage> {
                     controller: _obPostsStreamController,
                     secondaryRefresher: _refreshHashtag,
                     refresher: _refreshPosts,
-                    onScrollLoader: _loadMorePosts
-                ),
+                    onScrollLoader: _loadMorePosts),
               )
             ],
           ),

--- a/lib/pages/home/pages/hashtag/widgets/hashtag_nav_bar.dart
+++ b/lib/pages/home/pages/hashtag/widgets/hashtag_nav_bar.dart
@@ -12,8 +12,10 @@ import 'package:flutter/material.dart';
 class OBHashtagNavBar extends StatelessWidget
     implements ObstructingPreferredSizeWidget {
   final Hashtag hashtag;
+  final String rawHashtagName;
 
-  const OBHashtagNavBar({Key key, this.hashtag}) : super(key: key);
+  const OBHashtagNavBar({Key key, this.hashtag, this.rawHashtagName})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -37,8 +39,7 @@ class OBHashtagNavBar extends StatelessWidget
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
                       OBHashtag(
-                        hashtag: hashtag,
-                      ),
+                          hashtag: hashtag, rawHashtagName: rawHashtagName),
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 3),
                         child: Text(

--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -977,15 +977,16 @@ class NavigationService {
   }
 
   Future navigateToHashtag(
-      {@required Hashtag hashtag, @required BuildContext context}) async {
+      {@required Hashtag hashtag,
+      String rawHashtagName,
+      @required BuildContext context}) async {
     return Navigator.push(
       context,
       OBSlideRightRoute<dynamic>(
           slidableKey: _getKeyRandomisedWithWord('hashtagRoute'),
           builder: (BuildContext context) {
             return OBHashtagPage(
-              hashtag: hashtag
-            );
+                hashtag: hashtag, rawHashtagName: rawHashtagName);
           }),
     );
   }

--- a/lib/widgets/hashtag.dart
+++ b/lib/widgets/hashtag.dart
@@ -7,12 +7,14 @@ class OBHashtag extends StatelessWidget {
   final Hashtag hashtag;
   final ValueChanged<Hashtag> onPressed;
   final TextStyle textStyle;
+  final String rawHashtagName;
 
   const OBHashtag(
       {Key key,
       @required this.hashtag,
       this.onPressed,
-      this.textStyle})
+      this.textStyle,
+      this.rawHashtagName})
       : super(key: key);
 
   @override
@@ -23,26 +25,27 @@ class OBHashtag extends StatelessWidget {
     Color hashtagBackgroundColor = utilsService.parseHexColor(hashtag.color);
     Color hashtagTextColor = utilsService.parseHexColor(hashtag.textColor);
 
-
     TextStyle finalTextStyle = textStyle ?? TextStyle();
 
-    finalTextStyle = finalTextStyle.merge(TextStyle(color: hashtagTextColor, fontWeight: FontWeight.bold));
+    finalTextStyle = finalTextStyle
+        .merge(TextStyle(color: hashtagTextColor, fontWeight: FontWeight.bold));
 
-    Widget hashtagContent = Text('${hashtag.name}', style: finalTextStyle,);
+    Widget hashtagContent = Text(
+      rawHashtagName ?? hashtag.name,
+      style: finalTextStyle,
+    );
 
-
-
-    if(hashtag.hasEmoji()){
-      hashtagContent  = Row(
+    if (hashtag.hasEmoji()) {
+      hashtagContent = Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           Padding(
-            padding: const EdgeInsets.only(right: 4),
-            child: Image(
-              height: 15,
-              image: AdvancedNetworkImage(hashtag.emoji.image, useDiskCache: true),
-            )
-          ),
+              padding: const EdgeInsets.only(right: 4),
+              child: Image(
+                height: 15,
+                image: AdvancedNetworkImage(hashtag.emoji.image,
+                    useDiskCache: true),
+              )),
           hashtagContent
         ],
       );

--- a/lib/widgets/theming/actionable_smart_text.dart
+++ b/lib/widgets/theming/actionable_smart_text.dart
@@ -110,8 +110,8 @@ class OBActionableTextState extends State<OBActionableSmartText> {
     _setRequestSubscription(requestSubscription);
   }
 
-  void _onHashtagNameHashtagRetrieved(Hashtag hashtag) {
-    _navigationService.navigateToHashtag(hashtag: hashtag, context: context);
+  void _onHashtagNameHashtagRetrieved({Hashtag hashtag, String rawHashtagName}) {
+    _navigationService.navigateToHashtag(hashtag: hashtag, rawHashtagName: rawHashtagName, context: context);
   }
 
   void _onUsernameUserRetrieved(User user) {

--- a/lib/widgets/theming/smart_text.dart
+++ b/lib/widgets/theming/smart_text.dart
@@ -214,7 +214,7 @@ class OBSmartText extends StatelessWidget {
   final StringCallback onLinkTapped;
 
   /// Callback for tapping a link
-  final ValueChanged<Hashtag> onHashtagTapped;
+  final OnHashtagTapped onHashtagTapped;
 
   /// Callback for tapping a link
   final StringCallback onUsernameTapped;
@@ -275,7 +275,7 @@ class OBSmartText extends StatelessWidget {
       if (onUsernameTapped != null) {
         // Remove @
         String cleanedUsername =
-            username.substring(1, username.length).toLowerCase();
+        username.substring(1, username.length).toLowerCase();
         onUsernameTapped(cleanedUsername);
       }
     }
@@ -310,62 +310,67 @@ class OBSmartText extends StatelessWidget {
 
     return TextSpan(
         children: elements.map<InlineSpan>((element) {
-      InlineSpan textSpan;
-      if (element is TextElement) {
-        textSpan = TextSpan(
-          text: element.text,
-          style: style,
-        );
-      } else if (element is SecondaryTextElement) {
-        textSpan = TextSpan(
-          text: element.text,
-          style: secondaryTextStyle,
-        );
-      } else if (element is LinkElement) {
-        textSpan = LinkTextSpan(
-          text: element.text,
-          style: linkStyle,
-          onPressed: () => _onOpen(element.url),
-        );
-      } else if (element is HashtagElement) {
-        String hashtagText =
-            element.text.substring(1, element.text.length).toLowerCase();
-        if (this.hashtagsMap != null &&
-            this.hashtagsMap.containsKey(hashtagText)) {
-          Hashtag hashtag = this.hashtagsMap[hashtagText];
-          textSpan = WidgetSpan(
-              baseline: TextBaseline.alphabetic,
-              alignment: ui.PlaceholderAlignment.baseline,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 3),
-                child: OBHashtag(
-                  hashtag: hashtag,
-                  onPressed: onHashtagTapped,
-                  textStyle: usernameStyle,
-                ),
-              ));
-        } else {
-          textSpan = TextSpan(
-            text: element.text,
-            style: style,
-          );
-        }
-      } else if (element is UsernameElement) {
-        textSpan = LinkTextSpan(
-          text: element.text,
-          style: usernameStyle,
-          onPressed: () => _onUsernameTapped(element.username),
-        );
-      } else if (element is CommunityNameElement) {
-        textSpan = LinkTextSpan(
-          text: element.text,
-          style: communityNameStyle,
-          onPressed: () => _onCommunityNameTapped(element.communityName),
-        );
-      }
+          InlineSpan textSpan;
+          if (element is TextElement) {
+            textSpan = TextSpan(
+              text: element.text,
+              style: style,
+            );
+          } else if (element is SecondaryTextElement) {
+            textSpan = TextSpan(
+              text: element.text,
+              style: secondaryTextStyle,
+            );
+          } else if (element is LinkElement) {
+            textSpan = LinkTextSpan(
+              text: element.text,
+              style: linkStyle,
+              onPressed: () => _onOpen(element.url),
+            );
+          } else if (element is HashtagElement) {
+            String rawHashtagName =
+            element.text.substring(1, element.text.length);
+            String hashtagName = rawHashtagName.toLowerCase();
+            if (this.hashtagsMap != null &&
+                this.hashtagsMap.containsKey(hashtagName)) {
+              Hashtag hashtag = this.hashtagsMap[hashtagName];
+              textSpan = WidgetSpan(
+                  baseline: TextBaseline.alphabetic,
+                  alignment: ui.PlaceholderAlignment.baseline,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 3),
+                    child: OBHashtag(
+                      hashtag: hashtag,
+                      rawHashtagName: rawHashtagName,
+                      onPressed: (Hashtag hashtag) {
+                        if (onHashtagTapped != null) onHashtagTapped(
+                            hashtag: hashtag, rawHashtagName: rawHashtagName);
+                      },
+                      textStyle: usernameStyle,
+                    ),
+                  ));
+            } else {
+              textSpan = TextSpan(
+                text: element.text,
+                style: style,
+              );
+            }
+          } else if (element is UsernameElement) {
+            textSpan = LinkTextSpan(
+              text: element.text,
+              style: usernameStyle,
+              onPressed: () => _onUsernameTapped(element.username),
+            );
+          } else if (element is CommunityNameElement) {
+            textSpan = LinkTextSpan(
+              text: element.text,
+              style: communityNameStyle,
+              onPressed: () => _onCommunityNameTapped(element.communityName),
+            );
+          }
 
-      return textSpan;
-    }).toList());
+          return textSpan;
+        }).toList());
   }
 
   String runeSubstring({String input, int start, int end}) {
@@ -388,7 +393,7 @@ class OBSmartText extends StatelessWidget {
       if (length + elementLength > maxlength) {
         elements.removeRange(i + 1, elements.length);
         element.text = runeSubstring(
-                input: element.text, start: 0, end: maxlength - length)
+            input: element.text, start: 0, end: maxlength - length)
             .trimRight();
 
         if (lengthOverflow == TextOverflow.ellipsis) {
@@ -417,7 +422,7 @@ class OBSmartText extends StatelessWidget {
         OBTheme theme = snapshot.data;
 
         Color primaryTextColor =
-            themeValueParserService.parseColor(theme.primaryTextColor);
+        themeValueParserService.parseColor(theme.primaryTextColor);
 
         TextStyle textStyle = TextStyle(
             color: primaryTextColor,
@@ -429,8 +434,10 @@ class OBSmartText extends StatelessWidget {
         if (trailingSmartTextElement != null) {
           // This is ugly af, why do we even need this.
           Color secondaryTextColor =
-              themeValueParserService.parseColor(theme.secondaryTextColor);
-          secondaryTextColor = TinyColor(secondaryTextColor).lighten(10).color;
+          themeValueParserService.parseColor(theme.secondaryTextColor);
+          secondaryTextColor = TinyColor(secondaryTextColor)
+              .lighten(10)
+              .color;
           secondaryTextStyle = TextStyle(
               color: secondaryTextColor,
               fontSize: fontSize * 0.8,
@@ -470,8 +477,11 @@ class OBSmartText extends StatelessWidget {
 class LinkTextSpan extends TextSpan {
   LinkTextSpan({TextStyle style, VoidCallback onPressed, String text})
       : super(
-          style: style,
-          text: text,
-          recognizer: new TapGestureRecognizer()..onTap = onPressed,
-        );
+    style: style,
+    text: text,
+    recognizer: new TapGestureRecognizer()
+      ..onTap = onPressed,
+  );
 }
+
+typedef OnHashtagTapped({Hashtag hashtag, String rawHashtagName});


### PR DESCRIPTION
We display whatever casing people used for a given hashtag. When tapping it, we also preserve it on the hashtag page. When we want to add trending hashtags, we will have to have some sort of preferred hashtag casing for the showcased hashtags. 

I can imagine we could do something like that by adding hashtag variations like #hello -> #Hello, #hELLO and then counting which variation has the most uses and displaying that one as the correct one. For now this is a purely visual middleground until we do that.