### PR TITLE
Enhancement/search timelines

### DIFF
--- a/lib/pages/home/pages/search/search.dart
+++ b/lib/pages/home/pages/search/search.dart
@@ -74,7 +74,7 @@ class OBMainSearchPageState extends State<OBMainSearchPage>
   StreamSubscription<CommunitiesList> _getCommunitiesWithQuerySubscription;
   StreamSubscription<HashtagsList> _getHashtagsWithQuerySubscription;
 
-  Throttling _setScrollPositionDebouncer;
+  Throttling _setScrollPositionThrottler;
 
   static const double OB_BOTTOM_TAB_BAR_HEIGHT = 50.0;
   static const double HEIGHT_SEARCH_BAR = 76.0;
@@ -99,7 +99,7 @@ class OBMainSearchPageState extends State<OBMainSearchPage>
     _hashtagSearchResults = [];
     _selectedSearchResultsTab = OBUserSearchResultsTab.users;
     _tabController = new TabController(length: 2, vsync: this);
-    _setScrollPositionDebouncer = new Throttling(duration: Duration(milliseconds: 300));
+    _setScrollPositionThrottler = new Throttling(duration: Duration(milliseconds: 300));
     _animationController =
         AnimationController(vsync: this, duration: Duration(milliseconds: 100));
     _offset = Tween<Offset>(begin: Offset.zero, end: Offset(0.0, -1.0))
@@ -264,10 +264,10 @@ class OBMainSearchPageState extends State<OBMainSearchPage>
       if (_offset.value.dy == -1.0) _showTabSection();
       return;
     }
-    _setScrollPositionDebouncer.throttle(() => _handScrollDebounce(position.pixels, isScrollingUp));
+    _setScrollPositionThrottler.throttle(() => _handleScrollThrottle(position.pixels, isScrollingUp));
   }
 
-  void _handScrollDebounce(double scrollPixels, bool isScrollingUp) {
+  void _handleScrollThrottle(double scrollPixels, bool isScrollingUp) {
     if (_lastScrollPosition != null) {
         double offset = (scrollPixels - _lastScrollPosition).abs();
         if (offset > MIN_SCROLL_OFFSET_TO_ANIMATE_TABS) _checkScrollDirectionAndAnimateTabs(isScrollingUp);

--- a/lib/pages/home/pages/search/search.dart
+++ b/lib/pages/home/pages/search/search.dart
@@ -266,8 +266,6 @@ class OBMainSearchPageState extends State<OBMainSearchPage>
       return;
     }
 
-    // if (isScrollingUp == _isScrollingUp) return;
-
     if (isScrollingUp) {
       _showTabSection();
     } else {

--- a/lib/pages/home/pages/search/search.dart
+++ b/lib/pages/home/pages/search/search.dart
@@ -51,7 +51,6 @@ class OBMainSearchPageState extends State<OBMainSearchPage>
   ThemeValueParserService _themeValueParserService;
 
   bool _hasSearch;
-  bool _isScrollingUp;
   bool _userSearchRequestInProgress;
   bool _communitySearchRequestInProgress;
   bool _hashtagSearchRequestInProgress;
@@ -92,7 +91,6 @@ class OBMainSearchPageState extends State<OBMainSearchPage>
     _communitySearchRequestInProgress = false;
     _hashtagSearchRequestInProgress = false;
     _hasSearch = false;
-    _isScrollingUp = true;
     _heightTabs = HEIGHT_TABS_SECTION;
     _userSearchResults = [];
     _communitySearchResults = [];
@@ -424,16 +422,10 @@ class OBMainSearchPageState extends State<OBMainSearchPage>
 
   void _hideTabSection() {
     _animationController.forward();
-//    setState(() {
-//      _isScrollingUp = false;
-//    });
   }
 
   void _showTabSection() {
     _animationController.reverse();
-//    setState(() {
-//      _isScrollingUp = true;
-//    });
   }
 
   void _setHasSearch(bool hasSearch) {

--- a/lib/pages/home/pages/search/search.dart
+++ b/lib/pages/home/pages/search/search.dart
@@ -99,7 +99,6 @@ class OBMainSearchPageState extends State<OBMainSearchPage>
     _hashtagSearchResults = [];
     _selectedSearchResultsTab = OBUserSearchResultsTab.users;
     _tabController = new TabController(length: 2, vsync: this);
-    _isScrollingContinuouslyDebouncer = new Debouncing(duration: Duration(milliseconds: 100));
     _animationController =
         AnimationController(vsync: this, duration: Duration(milliseconds: 150));
     _offset = Tween<Offset>(begin: Offset.zero, end: Offset(0.0, -1.0))

--- a/lib/widgets/post/widgets/post-body/widgets/post_body_media/post_body_media.dart
+++ b/lib/widgets/post/widgets/post-body/widgets/post_body_media/post_body_media.dart
@@ -206,7 +206,7 @@ class OBPostBodyMediaState extends State<OBPostBodyMedia> {
     _setRetrievePostMediaInProgress(true);
     try {
       _retrievePostMediaOperation = CancelableOperation.fromFuture(
-          _userService.getMediaForPost(post: widget.post));
+          _userService.getMediaForPost(post: widget.post), onCancel: _onRetrievePostMediaOperationCancelled);
       PostMediaList mediaList = await _retrievePostMediaOperation.value;
       widget.post.setMedia(mediaList);
     } catch (error) {
@@ -214,6 +214,11 @@ class OBPostBodyMediaState extends State<OBPostBodyMedia> {
     } finally {
       _setRetrievePostMediaInProgress(false);
     }
+  }
+
+  void _onRetrievePostMediaOperationCancelled() {
+    debugPrint('Cancelled retrievePostMediaOperation');
+    _setRetrievePostMediaInProgress(false);
   }
 
   void _onError(error) async {
@@ -235,6 +240,7 @@ class OBPostBodyMediaState extends State<OBPostBodyMedia> {
   }
 
   void _setRetrievePostMediaInProgress(bool retrievePostMediaInProgress) {
+    if (!mounted) return;
     setState(() {
       _retrievePostMediaInProgress = retrievePostMediaInProgress;
     });


### PR DESCRIPTION
Trying out a smoother UX with the search tabs ( Explore and Trending posts) Havent been able to check on a phone due to xcode issues. Perhaps give it a go if possible @lifenautjoe ? 

[Edit] We now check the velocity of the scroll basically, there is a throttle function which checks the offset from the `_lastScrollPosition` and if its greater than a a particular constant we show/hide the tabs. 

