### PR TITLE
Bug/443 invite button state doesnt change

### DIFF
--- a/lib/models/updatable_model.dart
+++ b/lib/models/updatable_model.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:math';
 
 import 'package:dcache/dcache.dart';
 import 'package:meta/meta.dart';
@@ -68,6 +69,8 @@ abstract class UpdatableModelFactory<T extends UpdatableModel> {
 
 class UpdatableModelSimpleStorage<K, V extends UpdatableModel>
     implements Storage<K, V> {
+  static int MAX_INT = pow(2, 30) - 1; // (for 32 bit OS)
+
   Map<K, CacheEntry<K, V>> _internalMap;
   int _size;
 

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -52,7 +52,7 @@ class User extends UpdatableModel<User> {
 
   static final navigationUsersFactory = UserFactory(
       cache:
-          LfuCache<int, User>(storage: UpdatableModelSimpleStorage(size: 10)));
+          LfuCache<int, User>(storage: UpdatableModelSimpleStorage(size: 100)));
   static final sessionUsersFactory = UserFactory(
       cache: SimpleCache<int, User>(
           storage: UpdatableModelSimpleStorage(size: 10)));

--- a/lib/models/users_list.dart
+++ b/lib/models/users_list.dart
@@ -7,9 +7,9 @@ class UsersList {
     this.users,
   });
 
-  factory UsersList.fromJson(List<dynamic> parsedJson) {
+  factory UsersList.fromJson(List<dynamic> parsedJson, {storeInMaxSessionCache = false}) {
     List<User> users =
-        parsedJson.map((userJson) => User.fromJson(userJson)).toList();
+        parsedJson.map((userJson) => User.fromJson(userJson, storeInMaxSessionCache: storeInMaxSessionCache)).toList();
 
     return new UsersList(
       users: users,

--- a/lib/pages/home/modals/invite_to_community.dart
+++ b/lib/pages/home/modals/invite_to_community.dart
@@ -40,6 +40,12 @@ class OBInviteToCommunityModalState extends State<OBInviteToCommunityModal> {
   }
 
   @override
+  void dispose() {
+    super.dispose();
+    User.clearMaxSessionCache();
+  }
+
+  @override
   Widget build(BuildContext context) {
     if (_needsBootstrap) {
       var provider = OpenbookProvider.of(context);

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -238,6 +238,7 @@ class UserService {
       _removeLoggedInUser();
       await clearCache();
       User.clearSessionCache();
+      User.clearMaxSessionCache();
       _getOrCreateCurrentDeviceCache = null;
     }
   }
@@ -249,6 +250,7 @@ class UserService {
     await clearTemporaryDirectories();
     Post.clearCache();
     User.clearNavigationCache();
+    User.clearMaxSessionCache();
     PostComment.clearCache();
     Community.clearCache();
   }

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -949,7 +949,7 @@ class UserService {
     HttpieResponse response = await _authApiService.searchLinkedUsers(
         query: query, count: count, withCommunity: withCommunity.name);
     _checkResponseIsOk(response);
-    return UsersList.fromJson(json.decode(response.body));
+    return UsersList.fromJson(json.decode(response.body), storeInMaxSessionCache: true);
   }
 
   Future<UsersList> getLinkedUsers(
@@ -960,7 +960,7 @@ class UserService {
     HttpieResponse response = await _authApiService.getLinkedUsers(
         count: count, withCommunity: withCommunity?.name, maxId: maxId);
     _checkResponseIsOk(response);
-    return UsersList.fromJson(json.decode(response.body));
+    return UsersList.fromJson(json.decode(response.body), storeInMaxSessionCache: true);
   }
 
   Future<User> blockUser(User user) async {
@@ -1485,7 +1485,7 @@ class UserService {
         await _communitiesApiService.inviteUserToCommunity(
             communityName: community.name, username: user.username);
     _checkResponseIsCreated(response);
-    return User.fromJson(json.decode(response.body));
+    return User.fromJson(json.decode(response.body), storeInMaxSessionCache: true);
   }
 
   Future<void> uninviteUserFromCommunity(
@@ -1494,7 +1494,7 @@ class UserService {
         await _communitiesApiService.uninviteUserFromCommunity(
             communityName: community.name, username: user.username);
     _checkResponseIsOk(response);
-    return User.fromJson(json.decode(response.body));
+    return User.fromJson(json.decode(response.body),  storeInMaxSessionCache: true);
   }
 
   Future<CommunitiesList> getJoinedCommunities({int offset}) async {


### PR DESCRIPTION
Attempt to fix the invite state bug. 

Using a third cache in the user model with length equal to max int for a 32 bit OS, which can be made use of via a boolean `storeInMaxSessionCache` . 

Then Im using this cache when fetching the invite community users list.. and I clear this cache on dispose of that modal. 

Tested with 200+ users , works well. 