### PR TITLE
:globe_with_meridians: :bento: add link to Okuna roadmap in useful links

### DIFF
--- a/assets/i18n/en/drawer.arb
+++ b/assets/i18n/en/drawer.arb
@@ -183,6 +183,16 @@
     "type": "text",
     "placeholders": {}
   },
+  "useful_links_guidelines_roadmap": "The Okuna roadmap",
+  "@useful_links_guidelines_roadmap": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "useful_links_guidelines_roadmap_desc": "Take a look at what we're planning to do in the future",
+  "@useful_links_guidelines_roadmap_desc": {
+    "type": "text",
+    "placeholders": {}
+  },
   "useful_links_guidelines_feature_requests": "Feature requests",
   "@useful_links_guidelines_feature_requests": {
     "type": "text",

--- a/assets/i18n/en/post.arb
+++ b/assets/i18n/en/post.arb
@@ -339,11 +339,6 @@
     "type": "text",
     "placeholders": {}
   },
-  "community_not_found": "This community does not exist",
-  "@community_not_found": {
-    "type": "text",
-    "placeholders": {}
-  },
   "comments_view_all_comments": "View all {commentsCount} comments",
   "@comments_view_all_comments": {
     "type": "text",

--- a/assets/i18n/en/user.arb
+++ b/assets/i18n/en/user.arb
@@ -984,6 +984,16 @@
     "type": "text",
     "placeholders": {}
   },
+  "block_description": "You will both dissapear from each other's social network experience, with the exception of communities which the person is a staff member of.",
+  "@block_description": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "unblock_description": "You will both be able to follow, connect or explore each other's content again.",
+  "@unblock_description": {
+    "type": "text",
+    "placeholders": {}
+  },
   "unblock_user": "Unblock user",
   "@unblock_user": {
     "type": "text",

--- a/lib/pages/home/pages/menu/pages/useful_links.dart
+++ b/lib/pages/home/pages/menu/pages/useful_links.dart
@@ -50,6 +50,16 @@ class OBUsefulLinksPage extends StatelessWidget {
                   },
                 ),
                 ListTile(
+                  leading: const OBIcon(OBIcons.roadmap),
+                  title: OBText(_localizationService.drawer__useful_links_guidelines_roadmap),
+                  subtitle: OBSecondaryText(
+                      _localizationService.drawer__useful_links_guidelines_roadmap_desc),
+                  onTap: () {
+                    urlLauncherService.launchUrl(
+                        'https://okuna.io/roadmap');
+                  },
+                ),
+                ListTile(
                   leading: const OBIcon(OBIcons.featureRequest),
                   title: OBText(_localizationService.drawer__useful_links_guidelines_feature_requests),
                   subtitle: OBSecondaryText(

--- a/lib/services/localization.dart
+++ b/lib/services/localization.dart
@@ -754,6 +754,16 @@ class LocalizationService {
         name: 'drawer__useful_links_guidelines_github_desc');
   }
 
+  String get drawer__useful_links_guidelines_roadmap {
+    return Intl.message("The Okuna roadmap",
+        name: 'drawer__useful_links_guidelines_roadmap');
+  }
+
+  String get drawer__useful_links_guidelines_roadmap_desc {
+    return Intl.message("Take a look at what we're planning to do in the future",
+        name: 'drawer__useful_links_guidelines_roadmap_desc');
+  }
+
   String get drawer__useful_links_guidelines_feature_requests {
     return Intl.message("Feature requests",
         name: 'drawer__useful_links_guidelines_feature_requests');

--- a/lib/widgets/icon.dart
+++ b/lib/widgets/icon.dart
@@ -238,6 +238,7 @@ class OBIcons {
   static const guide = OBIconData(nativeIcon: Icons.book);
   static const slackChannel = OBIconData(nativeIcon: Icons.tag_faces);
   static const dashboard = OBIconData(nativeIcon: Icons.dashboard);
+  static const roadmap = OBIconData(nativeIcon: Icons.assignment);
   static const themes = OBIconData(nativeIcon: Icons.format_paint);
   static const invite = OBIconData(nativeIcon: Icons.card_giftcard);
   static const disableComments = OBIconData(nativeIcon: Icons.chat_bubble);


### PR DESCRIPTION
Following the discussion on Slack from November 25th, I added a new link in the Useful links section of the app. The link is https://okuna.io/roadmap as suggested by @duichwer - so before merging this, a redirect has to be added to the webserver configuration. Also, I have not generated the changes to the i18n files as I do not have sufficient rights to upload something to Crowdin