### PR TITLE
Make 'enter' presses do something in the login/registration forms

### DIFF
--- a/lib/pages/auth/create_account/create_account.dart
+++ b/lib/pages/auth/create_account/create_account.dart
@@ -220,6 +220,7 @@ class OBAuthCreateAccountPageState extends State<OBAuthCreateAccountPage> {
                   return null;
                 },
                 controller: _linkController,
+                onFieldSubmitted: (v) => onPressedNextStep(context),
               )),
         ),
       ]),

--- a/lib/pages/auth/create_account/email_step.dart
+++ b/lib/pages/auth/create_account/email_step.dart
@@ -203,6 +203,7 @@ class OBAuthEmailStepPageState extends State<OBAuthEmailStepPage> {
                   }
                 },
                 controller: _emailController,
+                onFieldSubmitted: (v) => onPressedNextStep(context),
               )
           ),
         ),

--- a/lib/pages/auth/create_account/name_step.dart
+++ b/lib/pages/auth/create_account/name_step.dart
@@ -167,6 +167,7 @@ class OBAuthNameStepPageState extends State<OBAuthNameStepPage> {
                   if (validateName != null) return validateName;
                 },
                 controller: _nameController,
+                onFieldSubmitted: (v) => onPressedNextStep(),
               )
           ),
         ),

--- a/lib/pages/auth/create_account/password_step.dart
+++ b/lib/pages/auth/create_account/password_step.dart
@@ -186,6 +186,7 @@ class OBAuthPasswordStepPageState extends State<OBAuthPasswordStepPage> {
                   },
                 ),
                 controller: _passwordController,
+                onFieldSubmitted: (v) => onPressedNextStep(),
               )),
         ),
       ]),

--- a/lib/pages/auth/create_account/username_step.dart
+++ b/lib/pages/auth/create_account/username_step.dart
@@ -201,6 +201,7 @@ class OBAuthUsernameStepPageState extends State<OBAuthUsernameStepPage> {
                   }
                 },
                 controller: _usernameController,
+                onFieldSubmitted: (v) => onPressedNextStep(context),
               )
           ),
         ),

--- a/lib/pages/auth/create_account/widgets/auth_text_field.dart
+++ b/lib/pages/auth/create_account/widgets/auth_text_field.dart
@@ -44,6 +44,8 @@ class OBAuthTextField extends StatelessWidget {
 
   final EdgeInsetsGeometry contentPadding;
 
+  final ValueChanged<String> onFieldSubmitted;
+
   OBAuthTextField({
     Key key,
     this.controller,
@@ -66,7 +68,8 @@ class OBAuthTextField extends StatelessWidget {
     this.enabled,
     this.keyboardAppearance,
     this.fontSize = 18.0,
-    this.contentPadding = const EdgeInsets.symmetric(vertical: 15.0, horizontal: 15.0)
+    this.contentPadding = const EdgeInsets.symmetric(vertical: 15.0, horizontal: 15.0),
+    this.onFieldSubmitted,
   });
 
   @override
@@ -101,6 +104,7 @@ class OBAuthTextField extends StatelessWidget {
         errorMaxLines: 2
       ),
       autofocus: autofocus,
+      onFieldSubmitted: onFieldSubmitted,
     );
   }
 }

--- a/lib/pages/auth/login.dart
+++ b/lib/pages/auth/login.dart
@@ -17,6 +17,7 @@ class OBAuthLoginPage extends StatefulWidget {
 
 class OBAuthLoginPageState extends State<OBAuthLoginPage> {
   final _formKey = GlobalKey<FormState>();
+  final _passwordFocusNode = FocusNode();
 
   bool _isSubmitted;
   bool _passwordIsVisible;
@@ -263,12 +264,16 @@ class OBAuthLoginPageState extends State<OBAuthLoginPage> {
                                 errorMaxLines: 3
                             ),
                             autocorrect: false,
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (v) => FocusScope.of(context)
+                                .requestFocus(_passwordFocusNode),
                           ),
                           const SizedBox(
                             height: 20.0,
                           ),
                           TextFormField(
                             controller: _passwordController,
+                            focusNode: _passwordFocusNode,
                             obscureText: !_passwordIsVisible,
                             validator: _validatePassword,
                             decoration: InputDecoration(

--- a/lib/pages/auth/login.dart
+++ b/lib/pages/auth/login.dart
@@ -17,7 +17,7 @@ class OBAuthLoginPage extends StatefulWidget {
 
 class OBAuthLoginPageState extends State<OBAuthLoginPage> {
   final _formKey = GlobalKey<FormState>();
-  final _passwordFocusNode = FocusNode();
+  FocusNode _passwordFocusNode;
 
   bool _isSubmitted;
   bool _passwordIsVisible;
@@ -35,6 +35,8 @@ class OBAuthLoginPageState extends State<OBAuthLoginPage> {
   void initState() {
     super.initState();
 
+    _passwordFocusNode = FocusNode();
+
     _loginInProgress = false;
     _isSubmitted = false;
     _passwordIsVisible = false;
@@ -48,6 +50,7 @@ class OBAuthLoginPageState extends State<OBAuthLoginPage> {
     super.dispose();
     _usernameController.removeListener(_validateForm);
     _passwordController.removeListener(_validateForm);
+    _passwordFocusNode.dispose();
   }
 
   @override

--- a/lib/pages/auth/login.dart
+++ b/lib/pages/auth/login.dart
@@ -123,13 +123,15 @@ class OBAuthLoginPageState extends State<OBAuthLoginPage> {
       minWidth: double.infinity,
       size: OBButtonSize.large,
       child: Text(buttonText, style: TextStyle(fontSize: 18.0)),
-      onPressed: () async {
-        _isSubmitted = true;
-        if (_validateForm()) {
-          await _login(context);
-        }
-      },
+      onPressed: _submitForm,
     );
+  }
+
+  Future<void> _submitForm() async {
+    _isSubmitted = true;
+    if (_validateForm()) {
+      await _login(context);
+    }
   }
 
   Future<void> _login(BuildContext context) async {
@@ -290,6 +292,7 @@ class OBAuthLoginPageState extends State<OBAuthLoginPage> {
                               border: OutlineInputBorder(),
                             ),
                             autocorrect: false,
+                            onFieldSubmitted: (v) => _submitForm(),
                           ),
                           const SizedBox(
                             height: 20.0,

--- a/lib/pages/auth/reset_password/forgot_password_step.dart
+++ b/lib/pages/auth/reset_password/forgot_password_step.dart
@@ -114,13 +114,15 @@ class OBAuthForgotPasswordPageState extends State<OBAuthForgotPasswordPage> {
       minWidth: double.infinity,
       size: OBButtonSize.large,
       child: Text(buttonText, style: TextStyle(fontSize: 18.0)),
-      onPressed: () async {
-        _isSubmitted = true;
-        if (_validateForm()) {
-          await _requestPasswordReset(context);
-        }
-      },
+      onPressed: _submitForm,
     );
+  }
+
+  Future<void> _submitForm() async {
+    _isSubmitted = true;
+    if (_validateForm()) {
+      await _requestPasswordReset(context);
+    }
   }
 
   Future<void> _requestPasswordReset(BuildContext context) async {
@@ -228,6 +230,7 @@ class OBAuthForgotPasswordPageState extends State<OBAuthForgotPasswordPage> {
                               errorMaxLines: 3
                             ),
                             autocorrect: false,
+                            onFieldSubmitted: (v) => _submitForm(),
                           ),
                         ],
                       )),

--- a/lib/pages/auth/reset_password/set_new_password_step.dart
+++ b/lib/pages/auth/reset_password/set_new_password_step.dart
@@ -210,6 +210,7 @@ class OBAuthSetNewPasswordPageState extends State<OBAuthSetNewPasswordPage> {
                   },
                 ),
                 controller: _passwordController,
+                onFieldSubmitted: (v) => onPressedNextStep(),
               )
           ),
         ),

--- a/lib/pages/auth/reset_password/verify_reset_password_link_step.dart
+++ b/lib/pages/auth/reset_password/verify_reset_password_link_step.dart
@@ -187,6 +187,7 @@ class OBAuthVerifyPasswordPageState extends State<OBAuthVerifyPasswordPage> {
                   }
                 },
                 controller: _linkController,
+                onFieldSubmitted: (v) => onPressedNextStep(context),
               )
           ),
         ),

--- a/lib/pages/waitlist/subscribe_email_step.dart
+++ b/lib/pages/waitlist/subscribe_email_step.dart
@@ -191,6 +191,7 @@ class OBWaitlistSubscribePageState extends State<OBWaitlistSubscribePage> {
                   if (validateEMail != null) return validateEMail;
                 },
                 controller: _emailController,
+                onFieldSubmitted: (v) => onPressedNextStep(context),
               )),
         ),
       ]),


### PR DESCRIPTION
Since the first alpha version I've found it a little bit annoying that pressing 'enter' in the login form doesn't move focus from the username field to the password field; instead it just closes the keyboard.

Since I don't need to enter my log in information very often I didn't spend time fixing it. But, I came across a solution to this a couple of days ago when I was looking for something else so it felt like it was time. :slightly_smiling_face: 

**Changes in this PR**
Login page:
- Keyboard shows a "Next" button in the username field. Pressing it focuses on the password field.
- Keyboard shows an "Enter" button (same as before this PR) in the password field. Pressing it triggers a login (same as tapping Continue).
- Pressing "Enter" also works in the forgot password, password reset link, and new password forms (same as tapping Continue/Next).

Registration flow:
- Pressing "Enter" goes to the next page (same as tapping Next).
