### PR TITLE
:ambulance: hotfix for slow read notifications API

### DIFF
--- a/lib/models/notifications/notification.dart
+++ b/lib/models/notifications/notification.dart
@@ -60,7 +60,7 @@ class OBNotification extends UpdatableModel<OBNotification> {
           contentObjectData: json['content_object'], type: type);
     }
 
-    if (json.containsKey('read')) {
+    if (json.containsKey('read') && !read) {
       read = json['read'];
     }
 

--- a/lib/pages/home/pages/notifications/notifications.dart
+++ b/lib/pages/home/pages/notifications/notifications.dart
@@ -279,6 +279,10 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
   }
 
   Future<List<OBNotification>> _refreshGeneralNotifications() async {
+    // TODO[Performance] remove on the _refreshNotifications call is faster
+    _generalNotificationsListController.items().forEach((OBNotification notification) {
+      notification.markNotificationAsRead();
+    });
     List<OBNotification> newNotifications =
         await _refreshNotifications(_generalTypes);
     await _refreshUnreadGeneralNotificationsCount();
@@ -286,6 +290,11 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
   }
 
   Future<List<OBNotification>> _refreshRequestNotifications() async {
+    // TODO[Performance] remove onthe the _refreshNotifications call is faster
+    _requestsNotificationsListController.items().forEach((OBNotification notification) {
+      notification.markNotificationAsRead();
+    });
+
     List<OBNotification> newNotifications =
         await _refreshNotifications(_requestTypes);
     await _refreshUnreadRequestNotificationsCount();
@@ -294,7 +303,9 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
 
   Future<List<OBNotification>> _refreshNotifications(
       [List<NotificationType> types]) async {
-    await _readNotifications(types: types);
+    // TODO[Performance] This API call takes ages so we're not awaiting anymore.
+    // When the perf is improved, make sure to await before requesting new notifications
+    _readNotifications(types: types);
 
     NotificationsList notificationsList =
         await _userService.getNotifications(types: types);
@@ -332,7 +343,7 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
     }
 
     int maxId = firstItem.id;
-    await _userService.readNotifications(maxId: maxId, types: types);
+    return _userService.readNotifications(maxId: maxId, types: types);
   }
 
   Future<List<OBNotification>> _loadMoreGeneralNotifications(

--- a/lib/widgets/http_list.dart
+++ b/lib/widgets/http_list.dart
@@ -676,6 +676,10 @@ class OBHttpListController<T> {
     return _state._list.isNotEmpty;
   }
 
+  List<T> items() {
+    return _state._list;
+  }
+
   T firstItem() {
     return _state._list.first;
   }


### PR DESCRIPTION
This is a hotfix for refreshing the notifications after first load which on profiles with tons of notifications, takes a millenia to load.

This wont wait for the server read notification API call to come back before retrieving new notifications and instead it will mark them as read locally. There is a chance that the data might be out of sync on app reset... however this is preferable than the alternative section taking 10+ seconds to load.

We'll fix the API, this is a temporal fix.