### PR TITLE
:package: revert image cropper to 1.1.2 because of not migrating to n…

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       name: image_cropper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.1.2"
   image_picker:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,7 @@ dependencies:
       path: packages/video_player
   sprintf: "^4.0.0"
   image_picker: 0.6.3+1
-  image_cropper: ^1.2.1
+  image_cropper: 1.1.2
   shimmer: ^1.0.0
   share: ^0.6.4
   path: ^1.7.0


### PR DESCRIPTION
Revert cropper that is throwing a missing implementation error because we haven't updated our flutter plugin build system. See https://github.com/OkunaOrg/okuna-app/pull/532