### PR TITLE
🐛 Fix community auto-complete moves cursor to start of text

### DIFF
--- a/lib/services/text_autocompletion.dart
+++ b/lib/services/text_autocompletion.dart
@@ -2,6 +2,10 @@ import 'package:Okuna/services/validation.dart';
 import 'package:flutter/cupertino.dart';
 
 class TextAutocompletionService {
+  static const String _usernamePrefix = '@';
+  static const String _hashtagPrefix = '#';
+  static const String _communityPrefix = 'c/';
+
   ValidationService _validationService;
 
   void setValidationService(validationService) {
@@ -16,21 +20,21 @@ class TextAutocompletionService {
       String lastWord =
           _getWordBeforeCursor(textController.text, cursorPosition);
 
-      if (lastWord.startsWith('@')) {
-        String searchQuery = lastWord.substring(1);
+      if (lastWord.startsWith(_usernamePrefix)) {
+        String searchQuery = lastWord.substring(_usernamePrefix.length);
         return TextAutocompletionResult(
             isAutocompleting: true,
             autocompleteQuery: searchQuery,
             type: TextAutocompletionType.account);
-      } else if (lastWord.startsWith('c/')) {
-        String searchQuery = lastWord.substring(3);
+      } else if (lastWord.startsWith(_communityPrefix)) {
+        String searchQuery = lastWord.substring(_communityPrefix.length);
         return TextAutocompletionResult(
             isAutocompleting: true,
             autocompleteQuery: searchQuery,
             type: TextAutocompletionType.community);
-      } else if (lastWord.startsWith('#') && lastWord.length > 1 &&
+      } else if (lastWord.startsWith(_hashtagPrefix) && lastWord.length > 1 &&
           _validationService.isPostTextContainingValidHashtags(lastWord)) {
-        String searchQuery = lastWord.substring(1);
+        String searchQuery = lastWord.substring(_hashtagPrefix.length);
         return TextAutocompletionResult(
             isAutocompleting: true,
             autocompleteQuery: searchQuery,
@@ -43,20 +47,20 @@ class TextAutocompletionService {
 
   void autocompleteTextWithUsername(
       TextEditingController textController, String username) {
-    _autocompleteText(textController, username, '@',
-        () => throw 'Tried to autocomplete text with username without @');
+    _autocompleteText(textController, username, _usernamePrefix,
+        () => throw 'Tried to autocomplete text with username without $_usernamePrefix');
   }
 
   void autocompleteTextWithHashtagName(
       TextEditingController textController, String hashtag) {
-    _autocompleteText(textController, hashtag, '#',
-        () => throw 'Tried to autocomplete text with hashtag without #');
+    _autocompleteText(textController, hashtag, _hashtagPrefix,
+        () => throw 'Tried to autocomplete text with hashtag without $_hashtagPrefix');
   }
 
   void autocompleteTextWithCommunityName(
       TextEditingController textController, String communityName) {
-    _autocompleteText(textController, communityName, 'c/',
-        () => throw 'Tried to autocomplete text with community name without c/');
+    _autocompleteText(textController, communityName, _communityPrefix,
+        () => throw 'Tried to autocomplete text with community name without $_communityPrefix');
   }
 
   String _getWordBeforeCursor(String text, int cursorPosition) {

--- a/lib/services/text_autocompletion.dart
+++ b/lib/services/text_autocompletion.dart
@@ -43,62 +43,20 @@ class TextAutocompletionService {
 
   void autocompleteTextWithUsername(
       TextEditingController textController, String username) {
-    String text = textController.text;
-    int cursorPosition = textController.selection.baseOffset;
-    String lastWord = _getWordBeforeCursor(text, cursorPosition);
-
-    if (!lastWord.startsWith('@')) {
-      throw 'Tried to autocomplete text with username without @';
-    }
-
-    var newText = text.substring(0, cursorPosition - lastWord.length) +
-        '@$username ' +
-        text.substring(cursorPosition);
-    var newSelection = TextSelection.collapsed(
-        offset: cursorPosition - lastWord.length + username.length + 2);
-
-    textController.value =
-        TextEditingValue(text: newText, selection: newSelection);
+    _autocompleteText(textController, username, '@',
+        () => throw 'Tried to autocomplete text with username without @');
   }
 
   void autocompleteTextWithHashtagName(
       TextEditingController textController, String hashtag) {
-    String text = textController.text;
-    int cursorPosition = textController.selection.baseOffset;
-    String lastWord = _getWordBeforeCursor(text, cursorPosition);
-
-    if (!lastWord.startsWith('#')) {
-      throw 'Tried to autocomplete text with hashtag without #';
-    }
-
-    var newText = text.substring(0, cursorPosition - lastWord.length) +
-        '#$hashtag ' +
-        text.substring(cursorPosition);
-    var newSelection = TextSelection.collapsed(
-        offset: cursorPosition - lastWord.length + hashtag.length + 2);
-
-    textController.value =
-        TextEditingValue(text: newText, selection: newSelection);
+    _autocompleteText(textController, hashtag, '#',
+        () => throw 'Tried to autocomplete text with hashtag without #');
   }
 
   void autocompleteTextWithCommunityName(
       TextEditingController textController, String communityName) {
-    String text = textController.text;
-    int cursorPosition = textController.selection.baseOffset;
-    String lastWord = _getWordBeforeCursor(text, cursorPosition);
-
-    if (!lastWord.startsWith('c/')) {
-      throw 'Tried to autocomplete text with community name without c/';
-    }
-
-    var newText = text.substring(0, cursorPosition - lastWord.length) +
-        'c/$communityName ' +
-        text.substring(cursorPosition);
-    var newSelection = TextSelection.collapsed(
-        offset: cursorPosition - lastWord.length + communityName.length + 3);
-
-    textController.value =
-        TextEditingValue(text: newText, selection: newSelection);
+    _autocompleteText(textController, communityName, 'c/',
+        () => throw 'Tried to autocomplete text with community name without c/');
   }
 
   String _getWordBeforeCursor(String text, int cursorPosition) {
@@ -108,6 +66,26 @@ class TextAutocompletionService {
     } else {
       return text;
     }
+  }
+
+  void _autocompleteText(TextEditingController textController, String value,
+      String prefix, VoidCallback onPrefixMissing) {
+    String text = textController.text;
+    int cursorPosition = textController.selection.baseOffset;
+    String lastWord = _getWordBeforeCursor(text, cursorPosition);
+
+    if (!lastWord.startsWith(prefix)) {
+      onPrefixMissing();
+    }
+
+    var newText = text.substring(0, cursorPosition - lastWord.length) +
+        '$prefix$value ' +
+        text.substring(cursorPosition);
+    var newSelection = TextSelection.collapsed(
+        offset: cursorPosition - lastWord.length + prefix.length + value.length + 1);
+
+    textController.value =
+        TextEditingValue(text: newText, selection: newSelection);
   }
 }
 

--- a/lib/services/text_autocompletion.dart
+++ b/lib/services/text_autocompletion.dart
@@ -95,7 +95,7 @@ class TextAutocompletionService {
         'c/$communityName ' +
         text.substring(cursorPosition);
     var newSelection = TextSelection.collapsed(
-        offset: cursorPosition - lastWord.length + communityName.length + 4);
+        offset: cursorPosition - lastWord.length + communityName.length + 3);
 
     textController.value =
         TextEditingValue(text: newText, selection: newSelection);

--- a/lib/services/text_autocompletion.dart
+++ b/lib/services/text_autocompletion.dart
@@ -78,14 +78,13 @@ class TextAutocompletionService {
       onPrefixMissing();
     }
 
-    var newText = text.substring(0, cursorPosition - lastWord.length) +
-        '$prefix$value ' +
-        text.substring(cursorPosition);
-    var newSelection = TextSelection.collapsed(
-        offset: cursorPosition - lastWord.length + prefix.length + value.length + 1);
+    var newTextStart =
+        text.substring(0, cursorPosition - lastWord.length) + '$prefix$value ';
+    var newTextEnd = text.substring(cursorPosition);
+    var newSelection = TextSelection.collapsed(offset: newTextStart.length);
 
-    textController.value =
-        TextEditingValue(text: newText, selection: newSelection);
+    textController.value = TextEditingValue(
+        text: newTextStart + newTextEnd, selection: newSelection);
   }
 }
 


### PR DESCRIPTION
After community auto completion the code tried to place the cursor 2 characters after the auto-completion. This meant that auto-completion at the end of a line would place the cursor after the last position in the line, which is invalid so Flutter treated it as 0.

Now we correctly place the the cursor only 1 character after the auto-completion.

I also reduced code duplication between the username, hashtag and community auto-completion methods.